### PR TITLE
Fetch the whole folder when sync_limit is 0 ("all")

### DIFF
--- a/crates/bridge/src/tuta.rs
+++ b/crates/bridge/src/tuta.rs
@@ -121,16 +121,22 @@ impl TutaSession {
         entries_list_id: &tutasdk::GeneratedId,
         limit: usize,
     ) -> Result<Vec<Mail>, ApiCallError> {
-        let count = if limit == 0 { 1000 } else { limit };
-        let entries: Vec<MailSetEntry> = self
-            .crypto_client()
-            .load_range(
-                entries_list_id,
-                &CustomId::default(),
-                count,
-                ListLoadDirection::DESC,
-            )
-            .await?;
+        // limit == 0 means "all": paginate the whole entries list. Otherwise
+        // load a single capped page (newest first).
+        let entries: Vec<MailSetEntry> = if limit == 0 {
+            self.crypto_client()
+                .load_all(entries_list_id, ListLoadDirection::DESC)
+                .await?
+        } else {
+            self.crypto_client()
+                .load_range(
+                    entries_list_id,
+                    &CustomId::default(),
+                    limit,
+                    ListLoadDirection::DESC,
+                )
+                .await?
+        };
 
         // Group entries by list_id for batch loading
         let mut by_list: std::collections::HashMap<String, Vec<tutasdk::GeneratedId>> =


### PR DESCRIPTION
## Summary
- `sync_limit = 0` used to still load a single 1000-entry page, so a folder was effectively capped.
- Use the SDK's paginated `load_all` to walk the entire `MailSetEntry` list when the limit is 0; keep a single capped `load_range` for a finite limit.
- Combined with persistent UIDs (#3), this lets the bridge mirror the **whole account** locally and keep it across restarts.

## Test plan
- [x] `cargo build` + `cargo test --workspace`
- [x] Live: `sync_limit = 0` → INBOX loads **all 19288 mails** (was capped at 500), UIDs 1..19288