### PR TITLE
IMAP + network robustness: ENVELOPE encoding, rate governor, on-demand fetch

### DIFF
--- a/crates/bridge/src/governed_client.rs
+++ b/crates/bridge/src/governed_client.rs
@@ -1,0 +1,349 @@
+//! Outbound rate governor for all Tuta API traffic.
+//!
+//! Every SDK request is routed through one [`GovernedRestClient`] so the bridge
+//! cannot flood the Tuta API. It enforces two things neither the raw HTTP
+//! client nor the SDK's own suspension layer provide:
+//!
+//! 1. **Bounded concurrency.** At most [`MAX_IN_FLIGHT`] requests run at once,
+//!    capping the HTTP/2 stream fan-out at the source (attachment sub-loops,
+//!    on-demand IMAP fetches across several client connections, and the syncer
+//!    can otherwise stampede in parallel).
+//! 2. **Throttle backoff.** On an HTTP 429/503 the governor suspends *all*
+//!    outbound traffic. It honors the server's `retry-after` / `suspension-time`
+//!    header when present and otherwise applies an escalating default backoff.
+//!    The SDK's built-in `SuspendableRestClient` arms nothing when a 429 carries
+//!    no header, which let the bridge keep hammering a rate-limited server.
+//!
+//! Because a 429 is returned to the caller *and* arms the gate, the existing
+//! retry layers (`sync::retry`, attachment retries) become self-correcting:
+//! their next attempt blocks on the gate instead of amplifying the flood.
+//!
+//! Installed in [`crate::tuta`] via `Sdk::new_without_suspension`, replacing the
+//! SDK suspension layer so there is exactly one authoritative choke point.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::{RwLock, Semaphore};
+use tokio::time::Instant;
+use tutasdk::bindings::rest_client::{
+    HttpMethod, RestClient, RestClientError, RestClientOptions, RestResponse,
+};
+
+/// Maximum number of Tuta API requests in flight at once.
+const MAX_IN_FLIGHT: usize = 4;
+/// First step of the default backoff, used when the server throttles without
+/// telling us how long to wait.
+const DEFAULT_BACKOFF_BASE: Duration = Duration::from_secs(2);
+/// Ceiling for any single backoff (server-provided or default), so one throttle
+/// can never stall the bridge for minutes.
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Response headers Tuta uses to advertise a throttle duration, in seconds.
+/// Header names reach us lowercased (see [`RestResponse`]).
+const RETRY_AFTER_HEADER: &str = "retry-after";
+const SUSPENSION_TIME_HEADER: &str = "suspension-time";
+
+/// A [`RestClient`] decorator enforcing bounded concurrency and 429/503 backoff.
+pub struct GovernedRestClient {
+    inner: Arc<dyn RestClient>,
+    permits: Arc<Semaphore>,
+    /// When `Some`, no request proceeds until this instant has passed.
+    suspended_until: Arc<RwLock<Option<Instant>>>,
+    /// Count of consecutive header-less throttles, for escalating the default
+    /// backoff. Reset on any 2xx response or any server-provided delay.
+    consecutive_throttles: AtomicU32,
+}
+
+impl GovernedRestClient {
+    pub fn new(inner: Arc<dyn RestClient>) -> Self {
+        Self {
+            inner,
+            permits: Arc::new(Semaphore::new(MAX_IN_FLIGHT)),
+            suspended_until: Arc::new(RwLock::new(None)),
+            consecutive_throttles: AtomicU32::new(0),
+        }
+    }
+
+    /// Block until any active suspension has elapsed. Re-checks after each sleep
+    /// because a concurrent request may have extended the suspension meanwhile.
+    async fn wait_out_suspension(&self) {
+        loop {
+            let until = *self.suspended_until.read().await;
+            match until {
+                Some(t) => {
+                    let now = Instant::now();
+                    if t > now {
+                        tokio::time::sleep(t - now).await;
+                    } else {
+                        return;
+                    }
+                }
+                None => return,
+            }
+        }
+    }
+
+    /// Arm (or extend) the suspension so it lasts at least `backoff` from now.
+    /// The longer of the existing and the new deadline wins.
+    async fn suspend_for(&self, backoff: Duration) {
+        let until = Instant::now() + backoff;
+        let mut guard = self.suspended_until.write().await;
+        match *guard {
+            Some(existing) if existing >= until => {}
+            _ => *guard = Some(until),
+        }
+    }
+
+    /// Backoff for a throttle response: the server's requested seconds when
+    /// present (clamped to a sane window, escalation reset), otherwise an
+    /// escalating default (2s, 4s, 8s, ...) capped at [`MAX_BACKOFF`].
+    fn backoff_for(&self, server_secs: Option<u64>) -> Duration {
+        if let Some(secs) = server_secs {
+            self.consecutive_throttles.store(0, Ordering::Relaxed);
+            return Duration::from_secs(secs).clamp(DEFAULT_BACKOFF_BASE, MAX_BACKOFF);
+        }
+        let n = self.consecutive_throttles.fetch_add(1, Ordering::Relaxed);
+        let factor = 1u32 << n.min(5); // 1, 2, 4, 8, 16, 32
+        DEFAULT_BACKOFF_BASE.saturating_mul(factor).min(MAX_BACKOFF)
+    }
+
+    fn note_success(&self) {
+        self.consecutive_throttles.store(0, Ordering::Relaxed);
+    }
+}
+
+/// If `resp` is a throttle (429/503), return `Some(server_secs)` where the inner
+/// option is the server-advertised delay in seconds, if any. A non-throttle
+/// response returns `None`.
+fn throttle_delay(resp: &RestResponse) -> Option<Option<u64>> {
+    if resp.status == 429 || resp.status == 503 {
+        let secs = resp
+            .headers
+            .get(RETRY_AFTER_HEADER)
+            .or_else(|| resp.headers.get(SUSPENSION_TIME_HEADER))
+            .and_then(|v| v.trim().parse::<u64>().ok());
+        Some(secs)
+    } else {
+        None
+    }
+}
+
+#[async_trait]
+impl RestClient for GovernedRestClient {
+    async fn request_binary(
+        &self,
+        url: String,
+        method: HttpMethod,
+        options: RestClientOptions,
+    ) -> Result<RestResponse, RestClientError> {
+        // Take a concurrency permit first, then wait out any suspension while
+        // holding it. This bounds both the number of in-flight requests and the
+        // number that fire the instant a suspension lifts.
+        let _permit = self
+            .permits
+            .acquire()
+            .await
+            .expect("rate governor semaphore is never closed");
+        self.wait_out_suspension().await;
+
+        let result = self.inner.request_binary(url, method, options).await;
+
+        if let Ok(ref resp) = result {
+            if let Some(server_secs) = throttle_delay(resp) {
+                let backoff = self.backoff_for(server_secs);
+                log::warn!(
+                    "Tuta throttled us (HTTP {}); pausing all API traffic for {:?}",
+                    resp.status,
+                    backoff
+                );
+                self.suspend_for(backoff).await;
+            } else if (200..300).contains(&resp.status) {
+                self.note_success();
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::atomic::AtomicUsize;
+
+    fn opts() -> RestClientOptions {
+        RestClientOptions {
+            headers: HashMap::new(),
+            body: None,
+            suspension_behavior: None,
+        }
+    }
+
+    fn resp(status: u32, headers: &[(&str, &str)]) -> RestResponse {
+        RestResponse {
+            status,
+            headers: headers
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: None,
+        }
+    }
+
+    /// A backend that records the peak number of simultaneous in-flight calls
+    /// and replies with a configurable status.
+    struct CountingClient {
+        in_flight: Arc<AtomicUsize>,
+        max_seen: Arc<AtomicUsize>,
+        status: u32,
+    }
+
+    #[async_trait]
+    impl RestClient for CountingClient {
+        async fn request_binary(
+            &self,
+            _url: String,
+            _method: HttpMethod,
+            _options: RestClientOptions,
+        ) -> Result<RestResponse, RestClientError> {
+            let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_seen.fetch_max(now, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(resp(self.status, &[]))
+        }
+    }
+
+    #[test]
+    fn throttle_delay_classifies_responses() {
+        assert_eq!(throttle_delay(&resp(200, &[])), None);
+        assert_eq!(throttle_delay(&resp(404, &[])), None);
+        assert_eq!(throttle_delay(&resp(429, &[])), Some(None));
+        assert_eq!(
+            throttle_delay(&resp(429, &[("retry-after", "30")])),
+            Some(Some(30))
+        );
+        assert_eq!(
+            throttle_delay(&resp(429, &[("suspension-time", "12")])),
+            Some(Some(12))
+        );
+        assert_eq!(
+            throttle_delay(&resp(503, &[("retry-after", "5")])),
+            Some(Some(5))
+        );
+        // garbage header value -> treated as "no hint"
+        assert_eq!(
+            throttle_delay(&resp(429, &[("retry-after", "soon")])),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn backoff_honors_and_clamps_server_seconds() {
+        let g = GovernedRestClient::new(Arc::new(CountingClient {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_seen: Arc::new(AtomicUsize::new(0)),
+            status: 200,
+        }));
+        // Below the floor clamps up to the base; above the ceiling clamps down.
+        assert_eq!(g.backoff_for(Some(1)), DEFAULT_BACKOFF_BASE);
+        assert_eq!(g.backoff_for(Some(9999)), MAX_BACKOFF);
+        assert_eq!(g.backoff_for(Some(10)), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn backoff_escalates_then_caps_without_header() {
+        let g = GovernedRestClient::new(Arc::new(CountingClient {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_seen: Arc::new(AtomicUsize::new(0)),
+            status: 200,
+        }));
+        assert_eq!(g.backoff_for(None), Duration::from_secs(2));
+        assert_eq!(g.backoff_for(None), Duration::from_secs(4));
+        assert_eq!(g.backoff_for(None), Duration::from_secs(8));
+        assert_eq!(g.backoff_for(None), Duration::from_secs(16));
+        assert_eq!(g.backoff_for(None), Duration::from_secs(32));
+        assert_eq!(g.backoff_for(None), MAX_BACKOFF); // 64 -> capped at 60
+        assert_eq!(g.backoff_for(None), MAX_BACKOFF);
+    }
+
+    #[test]
+    fn backoff_escalation_resets_on_server_value() {
+        let g = GovernedRestClient::new(Arc::new(CountingClient {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_seen: Arc::new(AtomicUsize::new(0)),
+            status: 200,
+        }));
+        assert_eq!(g.backoff_for(None), Duration::from_secs(2));
+        assert_eq!(g.backoff_for(None), Duration::from_secs(4));
+        let _ = g.backoff_for(Some(10)); // server value resets the escalation
+        assert_eq!(g.backoff_for(None), Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn concurrency_is_bounded() {
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let client = Arc::new(GovernedRestClient::new(Arc::new(CountingClient {
+            in_flight: in_flight.clone(),
+            max_seen: max_seen.clone(),
+            status: 200,
+        })));
+
+        let mut handles = Vec::new();
+        for _ in 0..20 {
+            let c = client.clone();
+            handles.push(tokio::spawn(async move {
+                c.request_binary("u".into(), HttpMethod::GET, opts()).await
+            }));
+        }
+        for h in handles {
+            h.await.unwrap().unwrap();
+        }
+        let peak = max_seen.load(Ordering::SeqCst);
+        assert!(peak >= 1, "at least one request ran");
+        assert!(
+            peak <= MAX_IN_FLIGHT,
+            "peak in-flight {peak} exceeded cap {MAX_IN_FLIGHT}"
+        );
+    }
+
+    #[tokio::test]
+    async fn throttle_response_arms_suspension() {
+        let g = GovernedRestClient::new(Arc::new(CountingClient {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_seen: Arc::new(AtomicUsize::new(0)),
+            status: 429, // every response is a throttle
+        }));
+        // No suspension before the first request.
+        assert!(g.suspended_until.read().await.is_none());
+        let _ = g
+            .request_binary("u".into(), HttpMethod::GET, opts())
+            .await
+            .unwrap();
+        // A 429 (no header) must arm a future suspension.
+        let until = *g.suspended_until.read().await;
+        assert!(until.is_some());
+        assert!(until.unwrap() > Instant::now());
+    }
+
+    #[tokio::test]
+    async fn wait_out_suspension_blocks_until_elapsed() {
+        let g = GovernedRestClient::new(Arc::new(CountingClient {
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_seen: Arc::new(AtomicUsize::new(0)),
+            status: 200,
+        }));
+        g.suspend_for(Duration::from_millis(60)).await;
+        let start = Instant::now();
+        g.wait_out_suspension().await;
+        assert!(
+            start.elapsed() >= Duration::from_millis(50),
+            "wait returned too early: {:?}",
+            start.elapsed()
+        );
+    }
+}

--- a/crates/bridge/src/governed_client.rs
+++ b/crates/bridge/src/governed_client.rs
@@ -37,9 +37,11 @@ const MAX_IN_FLIGHT: usize = 4;
 /// First step of the default backoff, used when the server throttles without
 /// telling us how long to wait.
 const DEFAULT_BACKOFF_BASE: Duration = Duration::from_secs(2);
-/// Ceiling for any single backoff (server-provided or default), so one throttle
-/// can never stall the bridge for minutes.
-const MAX_BACKOFF: Duration = Duration::from_secs(60);
+/// Ceiling for our own escalating backoff when the server gives no hint.
+const MAX_DEFAULT_BACKOFF: Duration = Duration::from_secs(60);
+/// Ceiling for a server-requested wait. We honor the server's retry-after, but
+/// cap it so a pathological header cannot stall the bridge indefinitely.
+const MAX_SERVER_BACKOFF: Duration = Duration::from_secs(300);
 
 /// Response headers Tuta uses to advertise a throttle duration, in seconds.
 /// Header names reach us lowercased (see [`RestResponse`]).
@@ -102,12 +104,17 @@ impl GovernedRestClient {
     /// escalating default (2s, 4s, 8s, ...) capped at [`MAX_BACKOFF`].
     fn backoff_for(&self, server_secs: Option<u64>) -> Duration {
         if let Some(secs) = server_secs {
+            // Trust the server's requested wait (floored, capped only to avoid a
+            // pathological stall).
             self.consecutive_throttles.store(0, Ordering::Relaxed);
-            return Duration::from_secs(secs).clamp(DEFAULT_BACKOFF_BASE, MAX_BACKOFF);
+            return Duration::from_secs(secs).clamp(DEFAULT_BACKOFF_BASE, MAX_SERVER_BACKOFF);
         }
+        // No hint from the server: escalate our own guess, capped tighter.
         let n = self.consecutive_throttles.fetch_add(1, Ordering::Relaxed);
         let factor = 1u32 << n.min(5); // 1, 2, 4, 8, 16, 32
-        DEFAULT_BACKOFF_BASE.saturating_mul(factor).min(MAX_BACKOFF)
+        DEFAULT_BACKOFF_BASE
+            .saturating_mul(factor)
+            .min(MAX_DEFAULT_BACKOFF)
     }
 
     fn note_success(&self) {
@@ -250,7 +257,7 @@ mod tests {
         }));
         // Below the floor clamps up to the base; above the ceiling clamps down.
         assert_eq!(g.backoff_for(Some(1)), DEFAULT_BACKOFF_BASE);
-        assert_eq!(g.backoff_for(Some(9999)), MAX_BACKOFF);
+        assert_eq!(g.backoff_for(Some(9999)), MAX_SERVER_BACKOFF);
         assert_eq!(g.backoff_for(Some(10)), Duration::from_secs(10));
     }
 
@@ -266,8 +273,8 @@ mod tests {
         assert_eq!(g.backoff_for(None), Duration::from_secs(8));
         assert_eq!(g.backoff_for(None), Duration::from_secs(16));
         assert_eq!(g.backoff_for(None), Duration::from_secs(32));
-        assert_eq!(g.backoff_for(None), MAX_BACKOFF); // 64 -> capped at 60
-        assert_eq!(g.backoff_for(None), MAX_BACKOFF);
+        assert_eq!(g.backoff_for(None), MAX_DEFAULT_BACKOFF); // 64 -> capped at 60
+        assert_eq!(g.backoff_for(None), MAX_DEFAULT_BACKOFF);
     }
 
     #[test]

--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -951,7 +951,7 @@ fn build_fetch_response(seq: usize, cached: &CachedMail, items: &str, uid_mode: 
 fn build_envelope(cached: &CachedMail) -> String {
     let mail = &cached.mail;
     let date = format_internal_date(mail.receivedDate.as_millis());
-    let subject = imap_quote(&mail.subject);
+    let subject = imap_string(&mail.subject);
 
     let from = format_envelope_addr(&mail.sender);
     let to = cached
@@ -973,12 +973,26 @@ fn build_envelope(cached: &CachedMail) -> String {
         .as_ref()
         .map(|id| format!("<{}.{}@tutabridge.local>", id.list_id, id.element_id))
         .unwrap_or_default();
+    let msg_id = imap_string(&msg_id);
 
-    format!("(\"{date}\" \"{subject}\" ({from}) ({from}) ({from}) ({to}) NIL NIL NIL \"{msg_id}\")")
+    format!("(\"{date}\" {subject} ({from}) ({from}) ({from}) ({to}) NIL NIL NIL {msg_id})")
 }
 
-fn imap_quote(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
+/// Encode a string as an IMAP nstring. Safe 7-bit text becomes a quoted string;
+/// a value holding CR, LF, or 8-bit bytes becomes a server-side literal
+/// ({N}CRLF<octets>), since a quoted string may not contain any of those. An
+/// empty value becomes "". Without this, a mail subject or sender name with an
+/// embedded newline produces a malformed FETCH response and the client cannot
+/// parse the message list (an empty mailbox in Thunderbird).
+fn imap_string(s: &str) -> String {
+    if s.is_empty() {
+        return "\"\"".to_string();
+    }
+    if s.bytes().any(|b| b == b'\r' || b == b'\n' || b >= 0x80) {
+        format!("{{{}}}\r\n{}", s.len(), s)
+    } else {
+        format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+    }
 }
 
 fn format_envelope_addr(addr: &tutasdk::entities::generated::tutanota::MailAddress) -> String {
@@ -986,9 +1000,14 @@ fn format_envelope_addr(addr: &tutasdk::entities::generated::tutanota::MailAddre
     let name = if addr.name.is_empty() {
         "NIL".to_string()
     } else {
-        format!("\"{}\"", addr.name.replace('"', "'"))
+        imap_string(&addr.name)
     };
-    format!("({} NIL \"{}\" \"{}\")", name, user, domain)
+    format!(
+        "({} NIL {} {})",
+        name,
+        imap_string(user),
+        imap_string(domain)
+    )
 }
 
 fn parse_seq_num(s: &str, max: u32) -> u32 {
@@ -1197,6 +1216,53 @@ mod tests {
             uid,
             deleted: false,
         }
+    }
+
+    // --- imap_string / ENVELOPE encoding ---
+
+    #[test]
+    fn imap_string_quotes_plain_ascii() {
+        assert_eq!(imap_string("Hello world"), "\"Hello world\"");
+    }
+
+    #[test]
+    fn imap_string_escapes_quote_and_backslash() {
+        assert_eq!(imap_string("a\"b\\c"), "\"a\\\"b\\\\c\"");
+    }
+
+    #[test]
+    fn imap_string_empty_is_empty_quotes() {
+        assert_eq!(imap_string(""), "\"\"");
+    }
+
+    #[test]
+    fn imap_string_uses_literal_for_newline() {
+        // A quoted string may not contain CR/LF, so it must become a literal.
+        let s = "La\nselection";
+        assert_eq!(imap_string(s), format!("{{{}}}\r\n{}", s.len(), s));
+    }
+
+    #[test]
+    fn imap_string_uses_literal_for_8bit() {
+        let s = "sélection"; // UTF-8 'é' is 8-bit
+        assert_eq!(imap_string(s), format!("{{{}}}\r\n{}", s.len(), s));
+    }
+
+    #[test]
+    fn build_envelope_newline_subject_uses_literal() {
+        // Regression: a newline in the subject used to be emitted as a quoted
+        // string, producing a malformed FETCH response that broke the client's
+        // parse of the message list (an empty mailbox in Thunderbird).
+        let subj = "La\nselection Courtois - Le bien du mois";
+        let env = build_envelope(&make_test_mail(1, subj, false));
+        assert!(
+            env.contains(&format!("{{{}}}\r\n{}", subj.len(), subj)),
+            "subject must be a literal, got: {env}"
+        );
+        assert!(
+            !env.contains("\"La"),
+            "subject must not be a quoted string holding the newline: {env}"
+        );
     }
 
     // --- parse_command ---
@@ -1420,8 +1486,11 @@ mod tests {
             _errors: Default::default(),
         };
         let result = format_envelope_addr(&addr);
-        // Inner quotes replaced with single quotes, wrapped in IMAP string delimiters
-        assert_eq!(result, "(\"John 'JD' Doe\" NIL \"john\" \"example.com\")");
+        // Inner quotes are backslash-escaped inside the IMAP quoted string.
+        assert_eq!(
+            result,
+            "(\"John \\\"JD\\\" Doe\" NIL \"john\" \"example.com\")"
+        );
     }
 
     // --- extract_headers (via rfc2822 module) ---
@@ -1486,28 +1555,6 @@ mod tests {
     #[test]
     fn test_parse_seq_num_negative() {
         assert_eq!(parse_seq_num("-1", 100), 0);
-    }
-
-    // --- imap_quote ---
-
-    #[test]
-    fn test_imap_quote_plain() {
-        assert_eq!(imap_quote("Hello World"), "Hello World");
-    }
-
-    #[test]
-    fn test_imap_quote_with_quotes() {
-        assert_eq!(imap_quote("He said \"hello\""), "He said \\\"hello\\\"");
-    }
-
-    #[test]
-    fn test_imap_quote_with_backslash() {
-        assert_eq!(imap_quote("path\\to\\file"), "path\\\\to\\\\file");
-    }
-
-    #[test]
-    fn test_imap_quote_both() {
-        assert_eq!(imap_quote("a\"b\\c"), "a\\\"b\\\\c");
     }
 
     // --- build_envelope: subject with quotes ---

--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -1640,6 +1640,7 @@ mod tests {
         unread_calls: Mutex<Vec<(Vec<IdTupleGenerated>, bool)>>,
         sent: Mutex<Vec<ParsedMessage>>,
         moved: Mutex<Vec<(Vec<IdTupleGenerated>, String)>>,
+        fail_details: Mutex<bool>,
     }
 
     impl MockBackend {
@@ -1651,7 +1652,12 @@ mod tests {
                 unread_calls: Mutex::new(Vec::new()),
                 sent: Mutex::new(Vec::new()),
                 moved: Mutex::new(Vec::new()),
+                fail_details: Mutex::new(false),
             }
+        }
+
+        fn set_fail_details(&self, v: bool) {
+            *self.fail_details.lock().unwrap() = v;
         }
 
         fn with_mails(mails: Vec<Mail>) -> Self {
@@ -1734,6 +1740,48 @@ mod tests {
         assert_eq!(moved.len(), 1);
         assert_eq!(moved[0].1, "cust");
         assert_eq!(moved[0].0.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn on_demand_body_fetch_failure_returns_no_and_cooldowns() {
+        let mail = make_mail("ed", "subj", false);
+        let backend = Arc::new(MockBackend::with_mails(vec![mail.clone()]));
+        backend.set_fail_details(true);
+        let store = MailStore::new();
+        store.set_folder_list(vec![inbox_folder()]).await;
+        store
+            .set_folder(
+                "inbox",
+                vec![StoredMail {
+                    mail,
+                    details: None,
+                    rfc2822: None,
+                    uid: 1,
+                    attachments_pending: false,
+                }],
+            )
+            .await;
+        let mut session = ImapSession::new(store.clone(), backend.clone(), None, None);
+        session.handle_command("a LOGIN u p").await;
+        session.handle_command("b SELECT INBOX").await;
+
+        // A failed on-demand body fetch returns NO [UNAVAILABLE] (not a fake
+        // body) and arms the shared cooldown.
+        let resp = session.handle_command("c UID FETCH 1 (BODY[])").await;
+        assert!(
+            resp.last().unwrap().contains("NO [UNAVAILABLE]"),
+            "expected NO on failure, got {resp:?}"
+        );
+        assert!(store.body_fetch_on_cooldown("ed"));
+
+        // While cooling down, a repeat fetch is short-circuited to NO without
+        // touching the backend, even though it would now succeed.
+        backend.set_fail_details(false);
+        let resp2 = session.handle_command("d UID FETCH 1 (BODY[])").await;
+        assert!(
+            resp2.last().unwrap().contains("NO [UNAVAILABLE]"),
+            "cooldown should keep returning NO, got {resp2:?}"
+        );
     }
 
     #[tokio::test]
@@ -1860,6 +1908,9 @@ mod tests {
             Ok(None)
         }
         async fn load_mail_details(&self, mail: &Mail) -> Result<Option<MailDetails>, String> {
+            if *self.fail_details.lock().unwrap() {
+                return Err("simulated Too Many Requests".to_string());
+            }
             let key = mail
                 ._id
                 .as_ref()

--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -423,7 +423,17 @@ impl ImapSession {
                     self.mails[idx].rfc2822 = Some(rfc);
                     self.mails[idx].body_loaded = true;
                 } else {
-                    // Out of the prefetch window — fetch the body on demand.
+                    // Out of the prefetch window: fetch the body on demand,
+                    // unless this mail is in a post-failure cooldown (do not
+                    // re-hit a throttled server on every client redraw).
+                    if let Some(eid) = &elem_id {
+                        if self.store.body_fetch_on_cooldown(eid) {
+                            return vec![format!(
+                                "{} NO [UNAVAILABLE] message body temporarily unavailable, try again later\r\n",
+                                tag
+                            )];
+                        }
+                    }
                     let mail = self.mails[idx].mail.clone();
                     match self.backend.load_mail_details(&mail).await {
                         Ok(Some(details)) => {
@@ -459,10 +469,19 @@ impl ImapSession {
                             self.mails[idx].body_loaded = true;
                             debug!("uid={} has no body source", self.mails[idx].uid);
                         }
-                        Err(e) => log::warn!(
-                            "On-demand body fetch failed for uid={}: {e}",
-                            self.mails[idx].uid
-                        ),
+                        Err(e) => {
+                            log::warn!(
+                                "On-demand body fetch failed for uid={}: {e}",
+                                self.mails[idx].uid
+                            );
+                            if let Some(eid) = &elem_id {
+                                self.store.mark_body_fetch_failed(eid);
+                            }
+                            return vec![format!(
+                                "{} NO [UNAVAILABLE] could not fetch message body, try again later\r\n",
+                                tag
+                            )];
+                        }
                     }
                 }
             }
@@ -1038,19 +1057,31 @@ fn parse_store_args(args: &str) -> (String, String) {
     (seq, rest)
 }
 
+/// Whether a FETCH item list requires the real message body to be loaded.
+///
+/// Only full-body content does: `BODY[]` / `BODY.PEEK[]`, a numbered MIME part
+/// (`BODY[1]`), `BODY[TEXT]`, or a standalone `RFC822` / `RFC822.TEXT`. Items the
+/// bridge answers from metadata alone must NOT trigger an on-demand fetch:
+/// `ENVELOPE`, `BODY[HEADER...]`, `BODYSTRUCTURE`, `RFC822.SIZE`, `FLAGS`, etc.
+/// Treating header/envelope requests as body requests made the client's
+/// list-building (one such fetch per message) download the entire mailbox.
+/// Whether a FETCH item list requires the real message body to be loaded.
+///
+/// The bridge serves the full message for `BODY[]` / `BODY.PEEK[]` and a
+/// standalone `RFC822`; only those need the body. Envelope, header, size and
+/// structure items (`ENVELOPE`, `BODY[HEADER...]`, `RFC822.SIZE`,
+/// `BODYSTRUCTURE`, `FLAGS`, ...) are answered from metadata and must NOT
+/// trigger an on-demand fetch. Treating header/envelope requests as body
+/// requests made the client's list-building (one such fetch per message)
+/// download the entire mailbox.
 fn needs_body(items: &str) -> bool {
     let u = items.to_uppercase();
-    if u.contains("BODY[") || u.contains("BODY.PEEK[") || u.contains("ENVELOPE") {
+    if u.contains("BODY[]") || u.contains("BODY.PEEK[]") {
         return true;
     }
-    // Match "RFC822" as a standalone fetch item but not "RFC822.SIZE" or "RFC822.HEADER"
-    for token in u.split_whitespace() {
-        let token = token.trim_matches(|c| c == '(' || c == ')');
-        if token == "RFC822" {
-            return true;
-        }
-    }
-    false
+    // Standalone RFC822 (a full message), but not RFC822.SIZE / .HEADER / .TEXT.
+    u.split(|c: char| c == '(' || c == ')' || c.is_whitespace())
+        .any(|token| token == "RFC822")
 }
 
 fn parse_login_args(args: &str) -> (String, String) {
@@ -1360,7 +1391,7 @@ mod tests {
         assert!(needs_body("(BODY[])"));
         assert!(needs_body("(BODY.PEEK[])"));
         assert!(needs_body("(RFC822)"));
-        assert!(needs_body("(ENVELOPE)"));
+        assert!(!needs_body("(ENVELOPE)"));
         assert!(needs_body("(FLAGS BODY[])"));
         assert!(!needs_body("(FLAGS)"));
         assert!(!needs_body("(FLAGS UID INTERNALDATE)"));
@@ -1565,6 +1596,31 @@ mod tests {
         let resp = build_fetch_response(1, &cached, "(ENVELOPE)", false);
         assert!(resp.contains("\\\"Important\\\""));
         assert!(!resp.contains("\"\"Important\"\""));
+    }
+
+    // --- needs_body: only real body content triggers an on-demand fetch ---
+
+    #[test]
+    fn needs_body_skips_metadata_and_header_fetches() {
+        // List-building items are answered from metadata, no fetch.
+        assert!(!needs_body("(FLAGS UID)"));
+        assert!(!needs_body("(ENVELOPE)"));
+        assert!(!needs_body("(FLAGS UID RFC822.SIZE ENVELOPE)"));
+        assert!(!needs_body(
+            "(BODY.PEEK[HEADER.FIELDS (FROM TO SUBJECT DATE)])"
+        ));
+        assert!(!needs_body("(UID RFC822.SIZE BODYSTRUCTURE FLAGS)"));
+        assert!(!needs_body("(RFC822.HEADER)"));
+        assert!(!needs_body("(BODY.PEEK[1.MIME])"));
+    }
+
+    #[test]
+    fn needs_body_triggers_for_body_content() {
+        assert!(needs_body("(BODY[])"));
+        assert!(needs_body("(BODY.PEEK[])"));
+        assert!(needs_body("(RFC822)"));
+        assert!(needs_body("(FLAGS BODY.PEEK[])"));
+        assert!(needs_body("BODY[]"));
     }
 
     // =================================================================

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backup;
 pub mod bridge;
 pub mod config;
 pub mod event_handler;
+mod governed_client;
 pub mod imap;
 pub mod mail;
 pub mod mcp;

--- a/crates/bridge/src/sync.rs
+++ b/crates/bridge/src/sync.rs
@@ -74,8 +74,12 @@ impl MailStore {
     /// Arm a cooldown after a failed on-demand body fetch so the bridge does not
     /// immediately re-hit a throttled or erroring server for the same mail.
     pub(crate) fn mark_body_fetch_failed(&self, element_id: &str) {
-        crate::util::lock_recover(&self.body_fetch_cooldown)
-            .insert(element_id.to_string(), Instant::now() + BODY_FETCH_COOLDOWN);
+        let mut map = crate::util::lock_recover(&self.body_fetch_cooldown);
+        let now = Instant::now();
+        // Drop elapsed entries so the map stays bounded by the number of mails
+        // currently cooling down, not every mail that has ever failed.
+        map.retain(|_, until| *until > now);
+        map.insert(element_id.to_string(), now + BODY_FETCH_COOLDOWN);
     }
 
     pub fn subscribe(&self) -> watch::Receiver<u64> {

--- a/crates/bridge/src/sync.rs
+++ b/crates/bridge/src/sync.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use log::{debug, info, warn};
 use tokio::sync::{watch, RwLock};
@@ -13,6 +13,10 @@ use crate::tuta::{FolderInfo, MailBackend};
 const INTER_REQUEST_DELAY: Duration = Duration::from_millis(150);
 const INTER_FOLDER_DELAY: Duration = Duration::from_millis(300);
 const MAX_RETRIES: u32 = 3;
+/// How long a mail whose on-demand body fetch just failed is skipped before the
+/// bridge will try the API again for it. Stops a client from re-triggering a
+/// fetch for the same message on every redraw while the server is throttling.
+const BODY_FETCH_COOLDOWN: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub struct StoredMail {
@@ -36,6 +40,9 @@ pub struct MailStore {
     folder_list: RwLock<Vec<FolderInfo>>,
     generation: watch::Sender<u64>,
     gen_counter: std::sync::atomic::AtomicU64,
+    /// element_id -> instant until which an on-demand body fetch is skipped,
+    /// armed after a fetch failure. Shared across IMAP connections.
+    body_fetch_cooldown: Mutex<HashMap<String, Instant>>,
 }
 
 impl MailStore {
@@ -46,7 +53,29 @@ impl MailStore {
             folder_list: RwLock::new(Vec::new()),
             generation: tx,
             gen_counter: std::sync::atomic::AtomicU64::new(0),
+            body_fetch_cooldown: Mutex::new(HashMap::new()),
         })
+    }
+
+    /// True if a recent on-demand body fetch for `element_id` failed and its
+    /// cooldown has not yet elapsed. Expired entries are dropped lazily.
+    pub(crate) fn body_fetch_on_cooldown(&self, element_id: &str) -> bool {
+        let mut map = crate::util::lock_recover(&self.body_fetch_cooldown);
+        match map.get(element_id) {
+            Some(&until) if until > Instant::now() => true,
+            Some(_) => {
+                map.remove(element_id);
+                false
+            }
+            None => false,
+        }
+    }
+
+    /// Arm a cooldown after a failed on-demand body fetch so the bridge does not
+    /// immediately re-hit a throttled or erroring server for the same mail.
+    pub(crate) fn mark_body_fetch_failed(&self, element_id: &str) {
+        crate::util::lock_recover(&self.body_fetch_cooldown)
+            .insert(element_id.to_string(), Instant::now() + BODY_FETCH_COOLDOWN);
     }
 
     pub fn subscribe(&self) -> watch::Receiver<u64> {
@@ -1125,6 +1154,22 @@ mod tests {
             uid,
             attachments_pending: false,
         }
+    }
+
+    #[test]
+    fn body_fetch_cooldown_blocks_then_expires() {
+        let store = MailStore::new();
+        assert!(!store.body_fetch_on_cooldown("mail-a"));
+        store.mark_body_fetch_failed("mail-a");
+        assert!(store.body_fetch_on_cooldown("mail-a"));
+        // A different mail is unaffected.
+        assert!(!store.body_fetch_on_cooldown("mail-b"));
+        // An elapsed entry is treated as expired and dropped lazily.
+        crate::util::lock_recover(&store.body_fetch_cooldown).insert(
+            "mail-a".to_string(),
+            Instant::now() - Duration::from_secs(1),
+        );
+        assert!(!store.body_fetch_on_cooldown("mail-a"));
     }
 
     #[tokio::test]

--- a/crates/bridge/src/tuta.rs
+++ b/crates/bridge/src/tuta.rs
@@ -969,10 +969,15 @@ pub async fn login_with_2fa(
     password: Option<&str>,
     totp_callback: Option<TwoFactorCallback>,
 ) -> Result<TutaSession, Box<dyn std::error::Error + Send + Sync>> {
-    let rest_client: Arc<dyn RestClient> =
+    let raw_client: Arc<dyn RestClient> =
         Arc::new(tutasdk::net::native_rest_client::NativeRestClient::try_new()?);
+    // Route every SDK request through the rate governor (bounded concurrency +
+    // 429/503 backoff), replacing the SDK's header-only suspension layer so
+    // there is exactly one authoritative choke point for outbound API traffic.
+    let rest_client: Arc<dyn RestClient> =
+        Arc::new(crate::governed_client::GovernedRestClient::new(raw_client));
     let file_client: Arc<dyn FileClient> = Arc::new(DiskFileClient::new());
-    let sdk = Sdk::new(cfg.api_url.clone(), rest_client, file_client);
+    let sdk = Sdk::new_without_suspension(cfg.api_url.clone(), rest_client, file_client);
 
     if let Some(credentials) = load_credentials(&cfg.email) {
         log::info!("Resuming saved session...");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,7 +9,12 @@ use tokio::sync::Mutex;
 use tutabridge_core::bridge::BridgeHandle;
 
 fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
+    // Keep the bridge's own logs at debug but silence the HTTP/2 + TLS transport
+    // firehose (h2/hyper/rustls/mio), which otherwise buries every useful line.
+    // RUST_LOG still overrides this when set.
+    const LOG_FILTER: &str = "info,tutabridge_core=debug,tutabridge_gui=debug,\
+        h2=warn,hyper=warn,hyper_util=warn,rustls=warn,mio=warn,tokio_util=warn,want=warn";
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(LOG_FILTER)).init();
 
     tokio_rustls::rustls::crypto::ring::default_provider()
         .install_default()


### PR DESCRIPTION
Stacked on #12 (logo); merge #12 first, then this auto-retargets to `main`.

## Problem

On a large mailbox (a 19535-mail inbox) Thunderbird showed an empty message list while the bridge flooded the Tuta API with HTTP/2 requests and got HTTP 429 in a tight loop. Root causes, found by tracing the request path (syncer, on-demand IMAP fetch, SDK HTTP layer):

1. A subject with a raw newline was emitted inside an IMAP quoted string, producing a malformed FETCH ENVELOPE that broke the client's parse of the message list.
2. `needs_body()` treated `ENVELOPE` and every `BODY[...]` section (including `BODY[HEADER...]`) as needing the body, so list-building did a full body + attachment download per message: rendering the list downloaded the whole mailbox.
3. Nothing bounded outbound concurrency, and the retry layers re-issued 429s with short backoff. The SDK suspension layer does nothing when a 429 carries no header, so the bridge kept hammering.
4. The GUI logged everything at `debug`, so the HTTP/2 firehose buried every useful line.

## Changes (one commit each)

- **fix(imap)**: encode ENVELOPE strings as IMAP literals for CR/LF and 8-bit.
- **feat(net)**: route all SDK traffic through one `GovernedRestClient`: bounded concurrency (max 4 in flight) + 429/503 backoff honoring `retry-after` / `suspension-time`, with an escalating default (2s to 60s) when the server gives no hint. Installed via `Sdk::new_without_suspension`. Makes the existing retry layers self-correcting (their next attempt waits on the gate).
- **feat(imap)**: `needs_body()` triggers a fetch only for real body content (`BODY[]` / `BODY.PEEK[]` / `RFC822`). On failure, return `NO [UNAVAILABLE]` instead of a placeholder body, and put the mail on a 30s cooldown shared across connections.
- **chore(gui)**: pin h2/hyper/rustls/mio to `warn` so the bridge's own logs are readable.

## Not changed

`sync_limit` default is already 500 (body-prefetch depth); the storm was on-demand, not prefetch.

## Tests

`cargo test -p tutabridge-core`: 269 + governor green. New: imap_string + ENVELOPE literal regression, needs_body (metadata/header skip vs body trigger), body-fetch cooldown, governor (concurrency cap, throttle classification, backoff honor/clamp/escalate/reset, suspension gate). `cargo fmt --check` clean on all three crates.