### PR TITLE
Bounded memory: body cache with LRU eviction, metadata-only store

### DIFF
--- a/crates/bridge/src/body_cache.rs
+++ b/crates/bridge/src/body_cache.rs
@@ -1,0 +1,256 @@
+//! Bounded in-memory cache for rendered message bodies.
+//!
+//! The `MailStore` keeps **metadata only**; the heavy per-mail payload (the
+//! rendered RFC 2822 string, attachments inlined as base64, plus the decrypted
+//! `MailDetails`) lives here, capped by [`MAX_CACHE_BYTES`] with LRU eviction.
+//! Eviction is safe because every body is also persisted encrypted on disk
+//! (`LocalStore::write_eml`): a miss re-reads and re-decrypts the `.eml.enc`.
+//!
+//! Before this cache, every fetched body was retained in the store (and
+//! re-cloned into each IMAP session's snapshot) forever: a client running a
+//! full offline sync of a large mailbox drove the bridge to a multi-gigabyte
+//! footprint. Now memory is bounded no matter how many bodies a client pulls.
+//!
+//! `MailDetails` is in-memory only (it is not persisted): after an eviction or
+//! a restart a body re-read from disk has `details: None`. Consumers fall back
+//! to metadata (e.g. ENVELOPE uses `firstRecipient`), which is the same
+//! behavior mails outside the prefetch window always had.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex, RwLock};
+
+use tutasdk::entities::generated::tutanota::MailDetails;
+
+use crate::store::LocalStore;
+
+/// Cap on the summed `rfc2822` bytes held in memory.
+const MAX_CACHE_BYTES: usize = 256 * 1024 * 1024;
+
+/// A cached body: the rendered message and, when it came fresh from the API,
+/// its decrypted details (used for ENVELOPE recipient lists and attachment
+/// retries).
+pub struct BodyEntry {
+    pub details: Option<MailDetails>,
+    pub rfc2822: String,
+}
+
+struct CacheState {
+    /// element id -> (entry, last-use tick)
+    entries: HashMap<String, (Arc<BodyEntry>, u64)>,
+    /// last-use tick -> element id (LRU order; lowest tick = coldest)
+    order: BTreeMap<u64, String>,
+    total_bytes: usize,
+    tick: u64,
+}
+
+pub struct BodyCache {
+    state: Mutex<CacheState>,
+    max_bytes: usize,
+    /// Set once at startup; `None` in unit tests (no disk fallback).
+    local_store: RwLock<Option<Arc<LocalStore>>>,
+}
+
+impl BodyCache {
+    pub fn new() -> Self {
+        Self::with_capacity(MAX_CACHE_BYTES)
+    }
+
+    pub fn with_capacity(max_bytes: usize) -> Self {
+        Self {
+            state: Mutex::new(CacheState {
+                entries: HashMap::new(),
+                order: BTreeMap::new(),
+                total_bytes: 0,
+                tick: 0,
+            }),
+            max_bytes,
+            local_store: RwLock::new(None),
+        }
+    }
+
+    pub fn set_local_store(&self, ls: Arc<LocalStore>) {
+        *crate::util::rwlock_write_recover(&self.local_store) = Some(ls);
+    }
+
+    /// Insert (or replace) a body. Evicts cold entries until the cache fits.
+    pub fn insert(&self, element_id: &str, entry: BodyEntry) {
+        let size = entry.rfc2822.len();
+        let mut st = crate::util::lock_recover(&self.state);
+        st.tick += 1;
+        let tick = st.tick;
+        if let Some((old, old_tick)) = st
+            .entries
+            .insert(element_id.to_string(), (Arc::new(entry), tick))
+        {
+            st.order.remove(&old_tick);
+            st.total_bytes -= old.rfc2822.len();
+        }
+        st.order.insert(tick, element_id.to_string());
+        st.total_bytes += size;
+
+        // Evict coldest-first until under budget. Never evict the entry we
+        // just inserted, even if it alone exceeds the budget (a single body is
+        // always allowed in memory so the FETCH that needs it can be served).
+        while st.total_bytes > self.max_bytes && st.entries.len() > 1 {
+            let Some((&cold_tick, _)) = st.order.iter().next() else {
+                break;
+            };
+            if cold_tick == tick {
+                break;
+            }
+            if let Some(eid) = st.order.remove(&cold_tick) {
+                if let Some((old, _)) = st.entries.remove(&eid) {
+                    st.total_bytes -= old.rfc2822.len();
+                }
+            }
+        }
+    }
+
+    /// Update the rendered body of an existing entry in place (attachment
+    /// retry rewrote the multipart). Details are preserved. No-op if the
+    /// entry is not cached.
+    pub fn update_rfc2822(&self, element_id: &str, rfc2822: String) {
+        let st = crate::util::lock_recover(&self.state);
+        if let Some((entry, _)) = st.entries.get(element_id) {
+            let details = entry.details.clone();
+            drop(st);
+            self.insert(element_id, BodyEntry { details, rfc2822 });
+        }
+    }
+
+    /// LRU-only lookup: refreshes recency, never touches the disk. Use for
+    /// per-message decorations (sizes, envelopes, search views) where a miss
+    /// must stay cheap.
+    pub fn cached(&self, element_id: &str) -> Option<Arc<BodyEntry>> {
+        let mut st = crate::util::lock_recover(&self.state);
+        st.tick += 1;
+        let tick = st.tick;
+        let (entry, old_tick) = st.entries.get_mut(element_id)?;
+        let entry = entry.clone();
+        let prev = std::mem::replace(old_tick, tick);
+        st.order.remove(&prev);
+        st.order.insert(tick, element_id.to_string());
+        Some(entry)
+    }
+
+    /// Lookup with disk fallback: on a miss, read and decrypt the persisted
+    /// `.eml.enc` (on the blocking pool) and cache it. Use for real content
+    /// requests (FETCH BODY[] / RFC822), which are naturally per-message.
+    pub async fn get(&self, element_id: &str) -> Option<Arc<BodyEntry>> {
+        if let Some(hit) = self.cached(element_id) {
+            return Some(hit);
+        }
+        let ls = crate::util::rwlock_read_recover(&self.local_store)
+            .as_ref()
+            .cloned()?;
+        let eid = element_id.to_string();
+        let rfc = tokio::task::spawn_blocking(move || ls.read_eml(&eid))
+            .await
+            .ok()?
+            .ok()
+            .flatten()?;
+        self.insert(
+            element_id,
+            BodyEntry {
+                details: None,
+                rfc2822: rfc,
+            },
+        );
+        self.cached(element_id)
+    }
+
+    #[cfg(test)]
+    fn total_bytes(&self) -> usize {
+        crate::util::lock_recover(&self.state).total_bytes
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        crate::util::lock_recover(&self.state).entries.len()
+    }
+}
+
+impl Default for BodyCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(body: &str) -> BodyEntry {
+        BodyEntry {
+            details: None,
+            rfc2822: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn insert_and_cached_roundtrip() {
+        let c = BodyCache::with_capacity(1024);
+        assert!(c.cached("a").is_none());
+        c.insert("a", entry("hello"));
+        assert_eq!(c.cached("a").unwrap().rfc2822, "hello");
+        assert_eq!(c.total_bytes(), 5);
+    }
+
+    #[test]
+    fn replacing_an_entry_updates_accounting() {
+        let c = BodyCache::with_capacity(1024);
+        c.insert("a", entry("aaaa"));
+        c.insert("a", entry("bb"));
+        assert_eq!(c.total_bytes(), 2);
+        assert_eq!(c.len(), 1);
+        assert_eq!(c.cached("a").unwrap().rfc2822, "bb");
+    }
+
+    #[test]
+    fn evicts_coldest_first_when_over_budget() {
+        let c = BodyCache::with_capacity(10);
+        c.insert("a", entry("aaaa")); // 4
+        c.insert("b", entry("bbbb")); // 8
+                                      // Touch `a` so `b` is the coldest.
+        assert!(c.cached("a").is_some());
+        c.insert("c", entry("cccc")); // 12 -> evict b
+        assert!(c.cached("b").is_none(), "coldest entry must be evicted");
+        assert!(c.cached("a").is_some());
+        assert!(c.cached("c").is_some());
+        assert!(c.total_bytes() <= 10);
+    }
+
+    #[test]
+    fn single_oversized_entry_is_kept() {
+        let c = BodyCache::with_capacity(4);
+        c.insert("big", entry("0123456789"));
+        assert!(
+            c.cached("big").is_some(),
+            "a single body larger than the budget must still be served"
+        );
+        // The next insert evicts it.
+        c.insert("small", entry("xy"));
+        assert!(c.cached("big").is_none());
+        assert!(c.cached("small").is_some());
+    }
+
+    #[test]
+    fn update_rfc2822_preserves_details_and_reaccounts() {
+        let c = BodyCache::with_capacity(1024);
+        c.insert("a", entry("original body"));
+        c.update_rfc2822("a", "new".to_string());
+        assert_eq!(c.cached("a").unwrap().rfc2822, "new");
+        assert_eq!(c.total_bytes(), 3);
+        // Unknown id is a no-op.
+        c.update_rfc2822("ghost", "x".to_string());
+        assert!(c.cached("ghost").is_none());
+    }
+
+    #[tokio::test]
+    async fn get_without_local_store_is_none_on_miss() {
+        let c = BodyCache::with_capacity(1024);
+        assert!(c.get("nope").await.is_none());
+        c.insert("a", entry("body"));
+        assert_eq!(c.get("a").await.unwrap().rfc2822, "body");
+    }
+}

--- a/crates/bridge/src/bridge.rs
+++ b/crates/bridge/src/bridge.rs
@@ -308,6 +308,9 @@ impl BridgeHandle {
         {
             let stats_dirty = self.stats_dirty_tx.clone();
             let mut store_watch = store.subscribe();
+            // Body-only updates ride a separate channel so they don't wake
+            // idle IMAP sessions; the stats display still wants them.
+            let mut details_watch = store.subscribe_details();
             let mut ws_watch = bus_client.state();
             let mut shutdown_watch = shutdown_sync_rx.clone();
             // Track the previous WS state so we only log on transitions,
@@ -320,6 +323,7 @@ impl BridgeHandle {
                 loop {
                     tokio::select! {
                         _ = store_watch.changed() => { let _ = stats_dirty.send(()); }
+                        _ = details_watch.changed() => { let _ = stats_dirty.send(()); }
                         _ = ws_watch.changed() => {
                             let now = *ws_watch.borrow();
                             if now != last_ws_state {

--- a/crates/bridge/src/event_handler.rs
+++ b/crates/bridge/src/event_handler.rs
@@ -350,19 +350,26 @@ async fn apply_mail_set_entry_create(
         });
         let mut stored = StoredMail {
             mail,
-            details: details.clone(),
-            rfc2822: rfc2822.clone(),
+            body_loaded: rfc2822.is_some(),
             uid: 0,
             attachments_pending: false,
         };
         // Persist the body straight away so the IMAP layer can serve FETCH
-        // BODY[] without a placeholder, and the prefetch loop skips it.
-        if let Some(eml) = rfc2822.as_deref() {
-            if let Err(e) = local_store.write_eml(&mail_eid, eml) {
+        // BODY[] without a placeholder, and the prefetch loop skips it. The
+        // in-memory copy goes into the bounded body cache.
+        if let Some(eml) = rfc2822 {
+            if let Err(e) = local_store.write_eml(&mail_eid, &eml) {
                 warn!("Failed to cache eml for {}: {e}", mail_eid);
             } else if let Err(e) = local_store.mark_has_details(&mail_eid) {
                 warn!("Failed to mark has_details for {}: {e}", mail_eid);
             }
+            store.bodies().insert(
+                &mail_eid,
+                crate::body_cache::BodyEntry {
+                    details,
+                    rfc2822: eml,
+                },
+            );
         }
         assign_uid_and_upsert(store, local_store, target_folder, &mail_eid, &mut stored).await;
         return;
@@ -390,8 +397,7 @@ async fn apply_mail_set_entry_create(
             );
             let mut stored = StoredMail {
                 mail,
-                details: None,
-                rfc2822: None,
+                body_loaded: false,
                 uid: 0,
                 attachments_pending: false,
             };

--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -19,13 +19,11 @@ enum State {
 
 struct CachedMail {
     mail: Mail,
-    details: Option<MailDetails>,
-    rfc2822: Option<String>,
-    /// `rfc2822` always carries the real headers, but for messages outside the
-    /// body-prefetch window it holds a placeholder body. `body_loaded` tracks
-    /// whether the *body* is final: `true` once we have real details (or have
-    /// confirmed the message has no body source), `false` while a body FETCH
-    /// still needs to pull it on demand.
+    /// True once the real body is available locally (bounded body cache or
+    /// encrypted disk cache); `false` while a body FETCH still needs to pull
+    /// it on demand. The body content itself is never held in the session:
+    /// snapshots used to clone every loaded body per connection, multiplying
+    /// the mailbox in memory by the number of clients.
     body_loaded: bool,
     uid: u32,
     deleted: bool,
@@ -394,38 +392,29 @@ impl ImapSession {
                 continue;
             }
 
+            let elem_id = self.mails[idx]
+                .mail
+                ._id
+                .as_ref()
+                .map(|id| id.element_id.to_string());
+
             // Make sure we have a renderable body before answering a body
             // FETCH. The mailbox lists every message, but only the newest
             // `sync_limit` bodies are pre-warmed — older ones are fetched
             // here, on demand, the first time a client opens them.
             if needs_body(&items) && !self.mails[idx].body_loaded {
-                let elem_id = self.mails[idx]
-                    .mail
-                    ._id
-                    .as_ref()
-                    .map(|id| id.element_id.to_string());
-
-                if self.mails[idx].details.is_some() {
-                    // Have details already, just render the envelope.
-                    let rfc = mail_to_rfc2822(
-                        &self.mails[idx].mail,
-                        self.mails[idx].details.as_ref(),
-                        &[],
-                    );
-                    self.mails[idx].rfc2822 = Some(rfc);
-                    self.mails[idx].body_loaded = true;
-                } else if let Some((details, rfc)) = match (&elem_id, &self.selected_folder) {
-                    // The syncer may have filled it in since our snapshot.
-                    (Some(eid), Some(folder)) => self.store.get_details(&folder.id, eid).await,
-                    _ => None,
-                } {
-                    self.mails[idx].details = Some(details);
-                    self.mails[idx].rfc2822 = Some(rfc);
+                // The syncer (or another connection) may have fetched it
+                // since our snapshot; the disk cache also counts.
+                let available = match &elem_id {
+                    Some(eid) => self.store.get_body(eid).await.is_some(),
+                    None => false,
+                };
+                if available {
                     self.mails[idx].body_loaded = true;
                 } else {
-                    // Out of the prefetch window: fetch the body on demand,
-                    // unless this mail is in a post-failure cooldown (do not
-                    // re-hit a throttled server on every client redraw).
+                    // Fetch the body on demand, unless this mail is in a
+                    // post-failure cooldown (do not re-hit a throttled server
+                    // on every client redraw).
                     if let Some(eid) = &elem_id {
                         if self.store.body_fetch_on_cooldown(eid) {
                             return vec![format!(
@@ -445,27 +434,36 @@ impl ImapSession {
                             let refs: Vec<(&TutanotaFile, &[u8])> =
                                 atts.iter().map(|(f, d)| (f, d.as_slice())).collect();
                             let rfc = mail_to_rfc2822(&mail, Some(&details), &refs);
-                            // Share into the in-memory store so other
-                            // connections (and stats) see it too.
                             if let (Some(eid), Some(folder)) = (&elem_id, &self.selected_folder) {
+                                // Persist first: the in-memory cache is
+                                // bounded, so the encrypted `.eml.enc` is what
+                                // makes this fetch survive eviction/restart.
+                                self.persist_body(eid, &rfc);
+                                // Share into the store cache so other
+                                // connections (and stats) see it too.
                                 self.store
-                                    .update_mail_details(
-                                        &folder.id,
-                                        eid,
-                                        details.clone(),
-                                        rfc.clone(),
-                                        false,
-                                    )
+                                    .update_mail_details(&folder.id, eid, details, rfc, false)
                                     .await;
                             }
-                            self.mails[idx].details = Some(details);
-                            self.mails[idx].rfc2822 = Some(rfc);
                             self.mails[idx].body_loaded = true;
                         }
                         Ok(None) => {
-                            // Legacy mail with no body reference — headers only.
-                            // Mark loaded so we don't re-hit the network on
-                            // every body FETCH of a message that has no body.
+                            // Legacy mail with no body reference — headers
+                            // only. Persist a headers-only `.eml` (as the
+                            // prefetch path does) so we don't re-hit the
+                            // network on every body FETCH of a message that
+                            // has no body.
+                            if let Some(eid) = &elem_id {
+                                let rfc = mail_to_rfc2822(&mail, None, &[]);
+                                self.persist_body(eid, &rfc);
+                                self.store.bodies().insert(
+                                    eid,
+                                    crate::body_cache::BodyEntry {
+                                        details: None,
+                                        rfc2822: rfc,
+                                    },
+                                );
+                            }
                             self.mails[idx].body_loaded = true;
                             debug!("uid={} has no body source", self.mails[idx].uid);
                         }
@@ -486,9 +484,22 @@ impl ImapSession {
                 }
             }
 
+            // One body lookup per message, shared by every FETCH item that
+            // needs content. Real body requests may fall back to the disk
+            // cache; decoration items (sizes, envelopes, structures) use the
+            // warm cache only, so building a message list never storms the
+            // disk with per-mail decrypts.
+            let body = match &elem_id {
+                Some(eid) if needs_body(&items) && self.mails[idx].body_loaded => {
+                    self.store.get_body(eid).await
+                }
+                Some(eid) if fetch_items_use_content(&items) => self.store.bodies().cached(eid),
+                _ => None,
+            };
+
             let cached = &self.mails[idx];
             let seq = idx + 1;
-            let resp = build_fetch_response(seq, cached, &items, uid_mode);
+            let resp = build_fetch_response(seq, cached, &items, uid_mode, body.as_deref());
             responses.push(resp);
         }
 
@@ -510,7 +521,15 @@ impl ImapSession {
             .iter()
             .enumerate()
             .filter(|(i, cached)| {
-                let view = Self::build_search_view(*i, cached);
+                // Warm-cache lookup only: search must not pull thousands of
+                // bodies off the disk. A cold body falls back to the
+                // metadata-rendered placeholder (real headers, stub body).
+                let body = cached
+                    .mail
+                    ._id
+                    .as_ref()
+                    .and_then(|id| self.store.bodies().cached(&id.element_id.to_string()));
+                let view = Self::build_search_view(*i, cached, body.as_deref());
                 search::matches(&query, &view, &ctx)
             })
             .map(|(i, cached)| if uid_mode { cached.uid } else { (i + 1) as u32 })
@@ -532,16 +551,29 @@ impl ImapSession {
     /// Project a cached message onto the fields IMAP SEARCH compares. Derived
     /// strings (From / To / Cc / Bcc / headers) are owned by the [`MsgView`];
     /// the cheap ones (subject, body) borrow straight from `cached`.
-    fn build_search_view(idx: usize, cached: &CachedMail) -> MsgView<'_> {
-        let headers = cached
-            .rfc2822
-            .as_deref()
-            .map(extract_headers)
-            .unwrap_or_default();
+    fn build_search_view<'a>(
+        idx: usize,
+        cached: &'a CachedMail,
+        body: Option<&crate::body_cache::BodyEntry>,
+    ) -> MsgView<'a> {
+        // A cold body means headers/size come from the placeholder rendering
+        // (real headers from metadata, stub body), same as unloaded messages.
+        let placeholder: Option<String> = if body.is_none() {
+            Some(mail_to_rfc2822(&cached.mail, None, &[]))
+        } else {
+            None
+        };
+        let rfc: &str = body
+            .map(|b| b.rfc2822.as_str())
+            .or(placeholder.as_deref())
+            .unwrap_or("");
+        let headers = extract_headers(rfc);
+        let size = rfc.len() as u64;
 
-        // To/Cc/Bcc come from details when the body is loaded; otherwise only
-        // the envelope `firstRecipient` (rendered as To) is available.
-        let (to, cc, bcc) = match cached.details.as_ref() {
+        // To/Cc/Bcc come from details when the body entry is warm; otherwise
+        // only the envelope `firstRecipient` (rendered as To) is available.
+        let details = body.and_then(|b| b.details.as_ref());
+        let (to, cc, bcc) = match details {
             Some(d) => (
                 join_addrs(&d.recipients.toRecipients),
                 join_addrs(&d.recipients.ccRecipients),
@@ -559,9 +591,7 @@ impl ImapSession {
             ),
         };
 
-        let sent_ms = cached
-            .details
-            .as_ref()
+        let sent_ms = details
             .map(|d| d.sentDate.as_millis())
             .unwrap_or_else(|| cached.mail.receivedDate.as_millis());
 
@@ -586,7 +616,7 @@ impl ImapSession {
             sent_ms,
             unread: cached.mail.unread,
             deleted: cached.deleted,
-            size: cached.rfc2822.as_ref().map(|r| r.len() as u64).unwrap_or(0),
+            size,
         }
     }
 
@@ -783,55 +813,38 @@ impl ImapSession {
         )]
     }
 
-    async fn refresh_mails(&mut self, folder_id: &str) -> Result<(), String> {
-        let stored = self.store.get_folder(folder_id).await;
+    /// Persist an on-demand-fetched body to the encrypted disk cache. The
+    /// in-memory body cache is bounded, so this is what makes the fetch
+    /// survive eviction and restarts (and lets the prefetch loop skip it).
+    fn persist_body(&self, element_id: &str, rfc2822: &str) {
+        let Some(ls) = &self.local_store else {
+            return;
+        };
+        if let Err(e) = ls.write_eml(element_id, rfc2822) {
+            log::warn!("Failed to cache eml {}: {}", element_id, e);
+            return;
+        }
+        if let Err(e) = ls.mark_has_details(element_id) {
+            log::warn!("Failed to mark has_details {}: {}", element_id, e);
+        }
+    }
 
-        // Carry over already-loaded details/rfc for this session.
-        let old_cache: std::collections::HashMap<String, (Option<MailDetails>, Option<String>)> =
-            self.mails
-                .iter()
-                .filter_map(|m| {
-                    let eid = m.mail._id.as_ref()?.element_id.to_string();
-                    Some((eid, (m.details.clone(), m.rfc2822.clone())))
-                })
-                .collect();
+    async fn refresh_mails(&mut self, folder_id: &str) -> Result<(), String> {
+        let mut stored = self.store.get_folder(folder_id).await;
 
         self.mails.clear();
         // UIDs are stable and assigned by the store; sort ascending so message
         // sequence order matches UID order, as IMAP clients expect.
-        let mut stored = stored;
         stored.sort_by_key(|m| m.uid);
 
         for sm in stored {
-            let elem_id = sm.mail._id.as_ref().map(|id| id.element_id.to_string());
-            let (old_details, old_rfc) = elem_id
-                .as_ref()
-                .and_then(|eid| old_cache.get(eid))
-                .cloned()
-                .unwrap_or((None, None));
-
             let uid = sm.uid;
             if uid >= self.uid_next {
                 self.uid_next = uid + 1;
             }
-
-            let details = sm.details.or(old_details);
-            // The body is final if we have real details, or a previously
-            // rendered rfc2822 (from the store or this session) — those always
-            // carry a real body. With none of those, the rfc2822 we render
-            // below has a placeholder body, so the body still needs an
-            // on-demand fetch the first time a client opens the message.
-            let body_loaded = details.is_some() || sm.rfc2822.is_some() || old_rfc.is_some();
-            let rfc2822 = sm
-                .rfc2822
-                .or(old_rfc)
-                .unwrap_or_else(|| mail_to_rfc2822(&sm.mail, details.as_ref(), &[]));
-
             self.mails.push(CachedMail {
                 mail: sm.mail,
-                details,
-                rfc2822: Some(rfc2822),
-                body_loaded,
+                body_loaded: sm.body_loaded,
                 uid,
                 deleted: false,
             });
@@ -896,9 +909,37 @@ fn join_addrs(addrs: &[MailAddress]) -> String {
         .join(", ")
 }
 
-fn build_fetch_response(seq: usize, cached: &CachedMail, items: &str, uid_mode: bool) -> String {
+/// True when any FETCH item needs message content (body, headers, size,
+/// structure, envelope) rather than pure metadata flags. Gates the per-message
+/// body-cache lookup in `cmd_fetch`.
+fn fetch_items_use_content(items: &str) -> bool {
+    let u = items.to_ascii_uppercase();
+    u.contains("BODY") || u.contains("RFC822") || u.contains("ENVELOPE")
+}
+
+/// `body` is the message's cached body when available. Items answered from the
+/// rendered message fall back to a placeholder rendering (real headers from
+/// metadata, stub body) when it is not, which is what unloaded messages have
+/// always returned.
+fn build_fetch_response(
+    seq: usize,
+    cached: &CachedMail,
+    items: &str,
+    uid_mode: bool,
+    body: Option<&crate::body_cache::BodyEntry>,
+) -> String {
     let items_upper = items.to_ascii_uppercase();
     let mut parts = Vec::new();
+
+    // Render the placeholder lazily: pure-metadata fetches (FLAGS, UID,
+    // INTERNALDATE) never pay for it.
+    let placeholder: Option<String> = if body.is_none() && fetch_items_use_content(items) {
+        Some(mail_to_rfc2822(&cached.mail, None, &[]))
+    } else {
+        None
+    };
+    let rfc: Option<&str> = body.map(|b| b.rfc2822.as_str()).or(placeholder.as_deref());
+    let details: Option<&MailDetails> = body.and_then(|b| b.details.as_ref());
 
     if uid_mode || items_upper.contains("UID") {
         parts.push(format!("UID {}", cached.uid));
@@ -921,19 +962,17 @@ fn build_fetch_response(seq: usize, cached: &CachedMail, items: &str, uid_mode: 
     }
 
     if items_upper.contains("RFC822.SIZE") {
-        let size = cached.rfc2822.as_ref().map(|r| r.len()).unwrap_or(0);
+        let size = rfc.map(|r| r.len()).unwrap_or(0);
         parts.push(format!("RFC822.SIZE {}", size));
     }
 
     if items_upper.contains("ENVELOPE") {
-        parts.push(format!("ENVELOPE {}", build_envelope(cached)));
+        parts.push(format!("ENVELOPE {}", build_envelope(cached, details)));
     }
 
     if items_upper.contains("BODYSTRUCTURE") {
-        let bs = cached
-            .rfc2822
-            .as_ref()
-            .map(|r| crate::mail::compute_bodystructure(r))
+        let bs = rfc
+            .map(crate::mail::compute_bodystructure)
             .unwrap_or_else(|| {
                 "(\"TEXT\" \"HTML\" (\"CHARSET\" \"UTF-8\") NIL NIL \"BASE64\" 0 0)".to_owned()
             });
@@ -941,11 +980,11 @@ fn build_fetch_response(seq: usize, cached: &CachedMail, items: &str, uid_mode: 
     }
 
     if items_upper.contains("BODY[]") || items_upper.contains("BODY.PEEK[]") {
-        if let Some(ref rfc) = cached.rfc2822 {
+        if let Some(rfc) = rfc {
             parts.push(format!("BODY[] {{{}}}\r\n{}", rfc.len(), rfc));
         }
     } else if let Some((section, fields, negate)) = parse_header_fields_section(items) {
-        if let Some(ref rfc) = cached.rfc2822 {
+        if let Some(rfc) = rfc {
             let headers = filter_header_fields(rfc, &fields, negate);
             parts.push(format!(
                 "BODY[{}] {{{}}}\r\n{}",
@@ -956,7 +995,7 @@ fn build_fetch_response(seq: usize, cached: &CachedMail, items: &str, uid_mode: 
         }
     } else if items_upper.contains("HEADER") {
         // Bare BODY[HEADER] / BODY.PEEK[HEADER] / RFC822.HEADER.
-        if let Some(ref rfc) = cached.rfc2822 {
+        if let Some(rfc) = rfc {
             let headers = extract_headers(rfc);
             let item = if items_upper.contains("RFC822.HEADER") {
                 "RFC822.HEADER"
@@ -971,7 +1010,7 @@ fn build_fetch_response(seq: usize, cached: &CachedMail, items: &str, uid_mode: 
         .split_whitespace()
         .any(|t| t.trim_matches(|c| c == '(' || c == ')') == "RFC822");
     if has_rfc822_full {
-        if let Some(ref rfc) = cached.rfc2822 {
+        if let Some(rfc) = rfc {
             parts.push(format!("RFC822 {{{}}}\r\n{}", rfc.len(), rfc));
         }
     }
@@ -1030,15 +1069,16 @@ fn filter_header_fields(rfc: &str, fields: &[String], negate: bool) -> String {
     out
 }
 
-fn build_envelope(cached: &CachedMail) -> String {
+/// `details` (when the body entry is warm in cache) provides the full To list;
+/// otherwise the envelope falls back to the metadata `firstRecipient`, as
+/// unloaded messages always have.
+fn build_envelope(cached: &CachedMail, details: Option<&MailDetails>) -> String {
     let mail = &cached.mail;
     let date = format_internal_date(mail.receivedDate.as_millis());
     let subject = imap_string(&mail.subject);
 
     let from = format_envelope_addr(&mail.sender);
-    let to = cached
-        .details
-        .as_ref()
+    let to = details
         .map(|d| {
             d.recipients
                 .toRecipients
@@ -1304,11 +1344,18 @@ mod tests {
                 clientSpamClassifierResult: None,
                 _errors: Default::default(),
             },
-            details: None,
-            rfc2822: Some("Date: Wed, 25 Dec 2024 12:30:45 +0000\r\nFrom: sender@tuta.com\r\nSubject: Test\r\n\r\nBody\r\n".to_string()),
             body_loaded: true,
             uid,
             deleted: false,
+        }
+    }
+
+    /// The body entry `make_test_mail` used to carry inline; tests pass it to
+    /// `build_fetch_response` explicitly now that bodies live in the cache.
+    fn make_test_body() -> crate::body_cache::BodyEntry {
+        crate::body_cache::BodyEntry {
+            details: None,
+            rfc2822: "Date: Wed, 25 Dec 2024 12:30:45 +0000\r\nFrom: sender@tuta.com\r\nSubject: Test\r\n\r\nBody\r\n".to_string(),
         }
     }
 
@@ -1348,7 +1395,7 @@ mod tests {
         // string, producing a malformed FETCH response that broke the client's
         // parse of the message list (an empty mailbox in Thunderbird).
         let subj = "La\nselection Courtois - Le bien du mois";
-        let env = build_envelope(&make_test_mail(1, subj, false));
+        let env = build_envelope(&make_test_mail(1, subj, false), None);
         assert!(
             env.contains(&format!("{{{}}}\r\n{}", subj.len(), subj)),
             "subject must be a literal, got: {env}"
@@ -1467,21 +1514,21 @@ mod tests {
     #[test]
     fn test_build_fetch_response_flags_only() {
         let cached = make_test_mail(1, "Test", false);
-        let resp = build_fetch_response(1, &cached, "(FLAGS)", false);
+        let resp = build_fetch_response(1, &cached, "(FLAGS)", false, None);
         assert_eq!(resp, "* 1 FETCH (FLAGS (\\Seen))\r\n");
     }
 
     #[test]
     fn test_build_fetch_response_flags_unread() {
         let cached = make_test_mail(1, "Test", true);
-        let resp = build_fetch_response(1, &cached, "(FLAGS)", false);
+        let resp = build_fetch_response(1, &cached, "(FLAGS)", false, None);
         assert_eq!(resp, "* 1 FETCH (FLAGS ())\r\n");
     }
 
     #[test]
     fn test_build_fetch_response_uid_mode() {
         let cached = make_test_mail(42, "Test", false);
-        let resp = build_fetch_response(3, &cached, "(FLAGS)", true);
+        let resp = build_fetch_response(3, &cached, "(FLAGS)", true, None);
         assert!(resp.contains("UID 42"));
         assert!(resp.contains("FLAGS (\\Seen)"));
     }
@@ -1489,22 +1536,32 @@ mod tests {
     #[test]
     fn test_build_fetch_response_internaldate() {
         let cached = make_test_mail(1, "Test", false);
-        let resp = build_fetch_response(1, &cached, "(INTERNALDATE)", false);
+        let resp = build_fetch_response(1, &cached, "(INTERNALDATE)", false, None);
         assert!(resp.contains("INTERNALDATE \"25-Dec-2024 12:37:25 +0000\""));
     }
 
     #[test]
     fn test_build_fetch_response_rfc822_size() {
         let cached = make_test_mail(1, "Test", false);
-        let resp = build_fetch_response(1, &cached, "(RFC822.SIZE)", false);
-        let rfc_len = cached.rfc2822.as_ref().unwrap().len();
-        assert!(resp.contains(&format!("RFC822.SIZE {}", rfc_len)));
+        let body = make_test_body();
+        let resp = build_fetch_response(1, &cached, "(RFC822.SIZE)", false, Some(&body));
+        assert!(resp.contains(&format!("RFC822.SIZE {}", body.rfc2822.len())));
+    }
+
+    #[test]
+    fn test_build_fetch_response_rfc822_size_placeholder_when_cold() {
+        // Without a cached body the size comes from the metadata-rendered
+        // placeholder, never 0.
+        let cached = make_test_mail(1, "Test", false);
+        let resp = build_fetch_response(1, &cached, "(RFC822.SIZE)", false, None);
+        assert!(!resp.contains("RFC822.SIZE 0"), "got: {resp}");
+        assert!(resp.contains("RFC822.SIZE "));
     }
 
     #[test]
     fn test_build_fetch_response_envelope() {
         let cached = make_test_mail(1, "Hello World", false);
-        let resp = build_fetch_response(1, &cached, "(ENVELOPE)", false);
+        let resp = build_fetch_response(1, &cached, "(ENVELOPE)", false, None);
         assert!(resp.contains("ENVELOPE"));
         assert!(resp.contains("Hello World"));
         assert!(resp.contains("\"sender\" \"tuta.com\""));
@@ -1513,7 +1570,8 @@ mod tests {
     #[test]
     fn test_build_fetch_response_body_peek() {
         let cached = make_test_mail(1, "Test", false);
-        let resp = build_fetch_response(1, &cached, "(BODY.PEEK[])", false);
+        let body = make_test_body();
+        let resp = build_fetch_response(1, &cached, "(BODY.PEEK[])", false, Some(&body));
         assert!(resp.contains("BODY[] {"));
         assert!(resp.contains("From: sender@tuta.com"));
     }
@@ -1521,7 +1579,8 @@ mod tests {
     #[test]
     fn test_build_fetch_response_rfc822_full() {
         let cached = make_test_mail(1, "Test", false);
-        let resp = build_fetch_response(1, &cached, "(RFC822)", false);
+        let body = make_test_body();
+        let resp = build_fetch_response(1, &cached, "(RFC822)", false, Some(&body));
         assert!(resp.contains("RFC822 {"));
         assert!(resp.contains("From: sender@tuta.com"));
     }
@@ -1611,7 +1670,7 @@ mod tests {
     #[test]
     fn test_build_fetch_response_multiple_items() {
         let cached = make_test_mail(5, "Multi", true);
-        let resp = build_fetch_response(3, &cached, "(FLAGS UID INTERNALDATE)", false);
+        let resp = build_fetch_response(3, &cached, "(FLAGS UID INTERNALDATE)", false, None);
         assert!(resp.starts_with("* 3 FETCH ("));
         assert!(resp.contains("FLAGS ()"));
         assert!(resp.contains("UID 5"));
@@ -1656,7 +1715,7 @@ mod tests {
     #[test]
     fn test_build_envelope_subject_with_quotes() {
         let cached = make_test_mail(1, "Re: \"Important\" stuff", false);
-        let resp = build_fetch_response(1, &cached, "(ENVELOPE)", false);
+        let resp = build_fetch_response(1, &cached, "(ENVELOPE)", false, None);
         assert!(resp.contains("\\\"Important\\\""));
         assert!(!resp.contains("\"\"Important\"\""));
     }
@@ -1668,11 +1727,13 @@ mod tests {
         let cached = make_test_mail(1, "Test", false);
         // Apple Mail-style request: long list, lowercase, includes fields the
         // message doesn't have. The response section must echo this list.
+        let body = make_test_body();
         let resp = build_fetch_response(
             1,
             &cached,
             "(BODY.PEEK[HEADER.FIELDS (date subject from x-priority x-universally-unique-identifier)])",
             false,
+            Some(&body),
         );
         assert!(
             resp.contains(
@@ -1726,10 +1787,11 @@ mod tests {
     #[test]
     fn bare_header_fetch_returns_all_headers() {
         let cached = make_test_mail(1, "Test", false);
-        let resp = build_fetch_response(1, &cached, "(BODY.PEEK[HEADER])", false);
+        let body = make_test_body();
+        let resp = build_fetch_response(1, &cached, "(BODY.PEEK[HEADER])", false, Some(&body));
         assert!(resp.contains("BODY[HEADER] {"), "got: {resp}");
         assert!(resp.contains("Subject: Test"));
-        let resp = build_fetch_response(1, &cached, "(RFC822.HEADER)", false);
+        let resp = build_fetch_response(1, &cached, "(RFC822.HEADER)", false, Some(&body));
         assert!(resp.contains("RFC822.HEADER {"), "got: {resp}");
     }
 
@@ -1845,15 +1907,13 @@ mod tests {
                 vec![
                     StoredMail {
                         mail: m1,
-                        details: None,
-                        rfc2822: None,
+                        body_loaded: false,
                         uid: 1,
                         attachments_pending: false,
                     },
                     StoredMail {
                         mail: m2,
-                        details: None,
-                        rfc2822: None,
+                        body_loaded: false,
                         uid: 2,
                         attachments_pending: false,
                     },
@@ -1889,8 +1949,7 @@ mod tests {
                 "inbox",
                 vec![StoredMail {
                     mail,
-                    details: None,
-                    rfc2822: None,
+                    body_loaded: false,
                     uid: 1,
                     attachments_pending: false,
                 }],
@@ -1980,8 +2039,7 @@ mod tests {
             .enumerate()
             .map(|(i, m)| StoredMail {
                 mail: m.clone(),
-                details: None,
-                rfc2822: None,
+                body_loaded: false,
                 uid: (i + 1) as u32,
                 attachments_pending: false,
             })
@@ -2199,21 +2257,33 @@ mod tests {
                 vec![
                     StoredMail {
                         mail: m1,
-                        details: Some(d1),
-                        rfc2822: Some(rfc1),
+                        body_loaded: true,
                         uid: 1,
                         attachments_pending: false,
                     },
                     StoredMail {
                         mail: m2,
-                        details: Some(d2),
-                        rfc2822: Some(rfc2),
+                        body_loaded: true,
                         uid: 2,
                         attachments_pending: false,
                     },
                 ],
             )
             .await;
+        store.bodies().insert(
+            "m1",
+            crate::body_cache::BodyEntry {
+                details: Some(d1),
+                rfc2822: rfc1,
+            },
+        );
+        store.bodies().insert(
+            "m2",
+            crate::body_cache::BodyEntry {
+                details: Some(d2),
+                rfc2822: rfc2,
+            },
+        );
         let mut session = ImapSession::new(store, backend, None, None);
 
         // LOGIN
@@ -2594,15 +2664,13 @@ mod tests {
                 vec![
                     StoredMail {
                         mail: m1,
-                        details: None,
-                        rfc2822: None,
+                        body_loaded: false,
                         uid: 1,
                         attachments_pending: false,
                     },
                     StoredMail {
                         mail: m2,
-                        details: None,
-                        rfc2822: None,
+                        body_loaded: false,
                         uid: 2,
                         attachments_pending: false,
                     },
@@ -2630,8 +2698,7 @@ mod tests {
                 "inbox",
                 vec![StoredMail {
                     mail: m1,
-                    details: None,
-                    rfc2822: None,
+                    body_loaded: false,
                     uid: 1,
                     attachments_pending: false,
                 }],
@@ -2665,15 +2732,13 @@ mod tests {
                 vec![
                     StoredMail {
                         mail: old1,
-                        details: None,
-                        rfc2822: None,
+                        body_loaded: false,
                         uid: 1,
                         attachments_pending: false,
                     },
                     StoredMail {
                         mail: new3,
-                        details: None,
-                        rfc2822: None,
+                        body_loaded: false,
                         uid: 3,
                         attachments_pending: false,
                     },
@@ -2707,8 +2772,7 @@ mod tests {
                 "inbox",
                 vec![StoredMail {
                     mail: m1,
-                    details: None,
-                    rfc2822: None,
+                    body_loaded: false,
                     uid: 1,
                     attachments_pending: false,
                 }],

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backup;
+pub mod body_cache;
 pub mod bridge;
 pub mod config;
 pub mod event_handler;

--- a/crates/bridge/src/mcp.rs
+++ b/crates/bridge/src/mcp.rs
@@ -387,12 +387,12 @@ async fn tool_get_message(state: &McpState, args: &Value) -> Result<String, Stri
 /// demand. Returns `None` (→ JSON null) when no body source exists.
 async fn load_body_text(
     state: &McpState,
-    folder_id: &str,
+    _folder_id: &str,
     element_id: &str,
     stored: &StoredMail,
 ) -> Option<String> {
-    if let Some((_details, rfc)) = state.store.get_details(folder_id, element_id).await {
-        return Some(extract_body_text(&rfc));
+    if let Some(body) = state.store.get_body(element_id).await {
+        return Some(extract_body_text(&body.rfc2822));
     }
     match state.backend.load_mail_details(&stored.mail).await {
         Ok(Some(details)) => {

--- a/crates/bridge/src/sync.rs
+++ b/crates/bridge/src/sync.rs
@@ -21,8 +21,12 @@ const BODY_FETCH_COOLDOWN: Duration = Duration::from_secs(30);
 #[derive(Clone)]
 pub struct StoredMail {
     pub mail: Mail,
-    pub details: Option<MailDetails>,
-    pub rfc2822: Option<String>,
+    /// True when the real body is available locally (in the [`BodyCache`] or
+    /// as a persisted `.eml.enc`). The body content itself is NOT stored here:
+    /// keeping every rendered body (attachments inlined) in the metadata store
+    /// grew the process by the size of the mailbox. Bodies live in the bounded
+    /// [`crate::body_cache::BodyCache`], backed by the on-disk cache.
+    pub body_loaded: bool,
     /// Stable IMAP UID within the folder, persisted across restarts.
     pub uid: u32,
     /// True while the mail's body has been rendered without its attachment
@@ -50,6 +54,8 @@ pub struct MailStore {
     /// element_id -> instant until which an on-demand body fetch is skipped,
     /// armed after a fetch failure. Shared across IMAP connections.
     body_fetch_cooldown: Mutex<HashMap<String, Instant>>,
+    /// Bounded LRU of rendered bodies (see [`crate::body_cache`]).
+    bodies: crate::body_cache::BodyCache,
 }
 
 impl MailStore {
@@ -63,7 +69,14 @@ impl MailStore {
             details_generation: details_tx,
             gen_counter: std::sync::atomic::AtomicU64::new(0),
             body_fetch_cooldown: Mutex::new(HashMap::new()),
+            bodies: crate::body_cache::BodyCache::new(),
         })
+    }
+
+    /// The bounded body cache. Wire the disk fallback once at startup with
+    /// [`crate::body_cache::BodyCache::set_local_store`].
+    pub fn bodies(&self) -> &crate::body_cache::BodyCache {
+        &self.bodies
     }
 
     /// True if a recent on-demand body fetch for `element_id` failed and its
@@ -124,21 +137,13 @@ impl MailStore {
             .unwrap_or_default()
     }
 
-    pub async fn get_details(
+    /// A mail's rendered body (LRU hit, or re-read from the encrypted disk
+    /// cache). `None` when the body was never fetched.
+    pub async fn get_body(
         &self,
-        folder_id: &str,
         element_id: &str,
-    ) -> Option<(MailDetails, String)> {
-        let folders = self.folders.read().await;
-        let folder = folders.get(folder_id)?;
-        folder.iter().find_map(|m| {
-            let eid = m.mail._id.as_ref()?.element_id.to_string();
-            if eid == element_id {
-                Some((m.details.clone()?, m.rfc2822.clone()?))
-            } else {
-                None
-            }
-        })
+    ) -> Option<std::sync::Arc<crate::body_cache::BodyEntry>> {
+        self.bodies.get(element_id).await
     }
 
     /// The current folder list (system + custom).
@@ -348,12 +353,18 @@ impl MailStore {
                     .as_deref()
                     == Some(element_id)
             }) {
-                m.details = Some(details);
-                m.rfc2822 = Some(rfc2822);
+                m.body_loaded = true;
                 m.attachments_pending = attachments_pending;
             }
         }
         drop(folders);
+        self.bodies.insert(
+            element_id,
+            crate::body_cache::BodyEntry {
+                details: Some(details),
+                rfc2822,
+            },
+        );
         self.bump_details_generation();
     }
 
@@ -373,11 +384,11 @@ impl MailStore {
                     .as_deref()
                     == Some(element_id)
             }) {
-                m.rfc2822 = Some(rfc2822);
                 m.attachments_pending = false;
             }
         }
         drop(folders);
+        self.bodies.update_rfc2822(element_id, rfc2822);
         self.bump_details_generation();
     }
 
@@ -417,6 +428,10 @@ pub async fn run_syncer(
             sync_limit.to_string()
         }
     );
+
+    // Give the body cache its disk fallback: an evicted (or not-yet-loaded)
+    // body is re-read from the encrypted `.eml.enc` on first use.
+    store.bodies().set_local_store(local_store.clone());
 
     // Fetch the folder list first; everything is keyed off it.
     let folders = match retry(|| backend.list_folders()).await {
@@ -671,37 +686,24 @@ async fn load_cached_folder(
             let mail: Mail = serde_json::from_str(&meta.mail_json)
                 .map_err(|e| format!("Bad cached mail {}: {e}", meta.element_id))?;
 
-            // Always try to recover the full body from disk first: the `.eml`
-            // file is the source of truth and may exist even when the metadata
-            // row says otherwise (a schema migration drops the `mails` table but
-            // keeps the encrypted `.eml.enc` files, so `has_details` is reset to
-            // 0 on first boot after the migration). Self-heal the row when we
-            // find an orphaned body, so the prefetch loop knows to skip it on
-            // the next sweep.
-            let rfc2822 = match ls.read_eml(&meta.element_id) {
-                Ok(Some(eml)) => {
-                    if !meta.has_details {
-                        if let Err(e) = ls.mark_has_details(&meta.element_id) {
-                            warn!("Failed to heal has_details for {}: {e}", meta.element_id);
-                        }
-                    }
-                    Some(eml)
+            // The `.eml` file on disk is the source of truth for "body
+            // available" and may exist even when the metadata row says
+            // otherwise (a schema migration drops the `mails` table but keeps
+            // the encrypted `.eml.enc` files, so `has_details` is reset to 0 on
+            // first boot after the migration). Self-heal the row when we find
+            // an orphaned body. The body content itself is NOT loaded here:
+            // decrypting every cached body at boot pinned the whole mailbox in
+            // memory; bodies are pulled into the bounded cache on first use.
+            let body_loaded = ls.has_eml(&meta.element_id);
+            if body_loaded && !meta.has_details {
+                if let Err(e) = ls.mark_has_details(&meta.element_id) {
+                    warn!("Failed to heal has_details for {}: {e}", meta.element_id);
                 }
-                // No cached body: leave `rfc2822` empty rather than baking in a
-                // placeholder. A placeholder would look like a real body to the
-                // IMAP layer and suppress the on-demand fetch; `None` is what tells
-                // it the body still has to be pulled the first time it's opened.
-                Ok(None) => None,
-                Err(e) => {
-                    warn!("Failed to read cached eml {}: {e}", meta.element_id);
-                    None
-                }
-            };
+            }
 
             stored_mails.push(StoredMail {
                 mail,
-                details: None,
-                rfc2822,
+                body_loaded,
                 uid: meta.uid as u32,
                 attachments_pending: false,
             });
@@ -777,18 +779,16 @@ pub(crate) async fn sync_folder(
         if let Some(existing) = elem_id.as_ref().and_then(|id| existing_map.get(id)) {
             updated.push(StoredMail {
                 mail: mail.clone(),
-                details: existing.details.clone(),
-                rfc2822: existing.rfc2822.clone(),
+                body_loaded: existing.body_loaded,
                 uid,
                 attachments_pending: existing.attachments_pending,
             });
         } else {
-            // New mail, body not fetched yet — leave `rfc2822` empty so the
-            // IMAP layer fetches it on demand (a placeholder would mask that).
+            // New mail, body not fetched yet — the IMAP layer fetches it on
+            // demand the first time a client opens it.
             updated.push(StoredMail {
                 mail: mail.clone(),
-                details: None,
-                rfc2822: None,
+                body_loaded: false,
                 uid,
                 attachments_pending: false,
             });
@@ -858,7 +858,7 @@ async fn prefetch_details(
     // First pass — messages in the prefetch window still missing their `.eml`.
     let api_needed: Vec<Mail> = prefetch_window
         .iter()
-        .filter(|m| m.details.is_none())
+        .filter(|m| !m.body_loaded)
         .filter_map(|m| {
             let eid = m.mail._id.as_ref()?.element_id.to_string();
             if local_store.has_eml(&eid) {
@@ -880,8 +880,11 @@ async fn prefetch_details(
             if !m.attachments_pending {
                 return None;
             }
-            let details = m.details.clone()?;
             let eid = m.mail._id.as_ref()?.element_id.to_string();
+            // A pending mail is fresh (the race resolves within minutes), so
+            // its details are still hot in the body cache. If they were
+            // evicted, skip this sweep; the pending flag keeps it eligible.
+            let details = store.bodies().cached(&eid)?.details.clone()?;
             if let Some(last) = attachment_retry_history.get(&eid) {
                 if now.duration_since(*last) < ATTACHMENT_RETRY_THROTTLE {
                     return None;
@@ -1035,14 +1038,14 @@ async fn prefetch_details(
                     eid
                 );
                 // Clear the pending flag so we don't keep retrying a
-                // permanent failure (e.g. server returned 404).
-                store
-                    .update_mail_rfc2822(
-                        &folder.id,
-                        &eid,
-                        stored.rfc2822.clone().unwrap_or_default(),
-                    )
-                    .await;
+                // permanent failure (e.g. server returned 404). The body-only
+                // rendering already in the cache stays as-is.
+                let body_only = store
+                    .bodies()
+                    .cached(&eid)
+                    .map(|e| e.rfc2822.clone())
+                    .unwrap_or_default();
+                store.update_mail_rfc2822(&folder.id, &eid, body_only).await;
                 attachment_retry_history.remove(&eid);
             }
         }
@@ -1181,8 +1184,7 @@ mod tests {
     fn stored(mail: Mail, uid: u32) -> StoredMail {
         StoredMail {
             mail,
-            details: None,
-            rfc2822: None,
+            body_loaded: false,
             uid,
             attachments_pending: false,
         }

--- a/crates/bridge/src/sync.rs
+++ b/crates/bridge/src/sync.rs
@@ -38,7 +38,14 @@ pub struct MailStore {
     folders: RwLock<HashMap<String, Vec<StoredMail>>>,
     /// The folder list (system + custom), for IMAP enumeration.
     folder_list: RwLock<Vec<FolderInfo>>,
+    /// Bumped on list-membership changes (mail added/removed, folder list).
+    /// IMAP sessions and the prefetch loop wake on this one.
     generation: watch::Sender<u64>,
+    /// Bumped on body-only updates (details/rfc2822 stored). Only the GUI
+    /// stats watcher subscribes: waking every idle IMAP session for each of
+    /// thousands of arriving bodies made each one deep-clone the folder per
+    /// body (the CPU/memory storm).
+    details_generation: watch::Sender<u64>,
     gen_counter: std::sync::atomic::AtomicU64,
     /// element_id -> instant until which an on-demand body fetch is skipped,
     /// armed after a fetch failure. Shared across IMAP connections.
@@ -48,10 +55,12 @@ pub struct MailStore {
 impl MailStore {
     pub fn new() -> Arc<Self> {
         let (tx, _) = watch::channel(0u64);
+        let (details_tx, _) = watch::channel(0u64);
         Arc::new(Self {
             folders: RwLock::new(HashMap::new()),
             folder_list: RwLock::new(Vec::new()),
             generation: tx,
+            details_generation: details_tx,
             gen_counter: std::sync::atomic::AtomicU64::new(0),
             body_fetch_cooldown: Mutex::new(HashMap::new()),
         })
@@ -84,6 +93,13 @@ impl MailStore {
 
     pub fn subscribe(&self) -> watch::Receiver<u64> {
         self.generation.subscribe()
+    }
+
+    /// Watch body-only updates (a mail's details/rfc2822 landed). Cheap,
+    /// high-frequency during prefetch; meant for stats display, not for
+    /// anything that re-reads folder contents.
+    pub fn subscribe_details(&self) -> watch::Receiver<u64> {
+        self.details_generation.subscribe()
     }
 
     pub async fn total_mail_count(&self) -> usize {
@@ -338,7 +354,7 @@ impl MailStore {
             }
         }
         drop(folders);
-        self.bump_generation();
+        self.bump_details_generation();
     }
 
     /// Rewrite just the cached RFC 2822 for a mail (and clear its pending
@@ -362,7 +378,7 @@ impl MailStore {
             }
         }
         drop(folders);
-        self.bump_generation();
+        self.bump_details_generation();
     }
 
     fn bump_generation(&self) {
@@ -371,6 +387,18 @@ impl MailStore {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             + 1;
         self.generation.send_replace(gen);
+    }
+
+    /// Signal a body-only update. Deliberately NOT the list generation: a body
+    /// landing changes no EXISTS/EXPUNGE, so waking every idle IMAP session
+    /// (which each deep-clone the folder to diff it) per arriving body is pure
+    /// waste, at thousands of bodies per sync.
+    fn bump_details_generation(&self) {
+        let gen = self
+            .gen_counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        self.details_generation.send_replace(gen);
     }
 }
 
@@ -1158,6 +1186,59 @@ mod tests {
             uid,
             attachments_pending: false,
         }
+    }
+
+    #[tokio::test]
+    async fn body_updates_wake_details_watchers_not_list_watchers() {
+        use tutasdk::entities::generated::tutanota::{Body, Recipients};
+        let details = MailDetails {
+            _id: None,
+            sentDate: DateTime::from_millis(0),
+            authStatus: 0,
+            replyTos: vec![],
+            recipients: Recipients {
+                _id: None,
+                toRecipients: vec![],
+                ccRecipients: vec![],
+                bccRecipients: vec![],
+            },
+            headers: None,
+            body: Body {
+                _id: None,
+                text: Some("hi".into()),
+                compressedText: None,
+                _errors: Default::default(),
+            },
+        };
+
+        let store = MailStore::new();
+        store
+            .set_folder("f", vec![stored(make_mail("l", "e1", "s", false), 1)])
+            .await;
+        let mut list_watch = store.subscribe();
+        let mut details_watch = store.subscribe_details();
+        list_watch.borrow_and_update();
+        details_watch.borrow_and_update();
+
+        // A body landing must signal stats watchers without waking the list
+        // watchers every idle IMAP session sleeps on (the clone storm).
+        store
+            .update_mail_details("f", "e1", details, "body".into(), false)
+            .await;
+        assert!(
+            !list_watch.has_changed().unwrap(),
+            "body-only update must not wake list watchers"
+        );
+        assert!(
+            details_watch.has_changed().unwrap(),
+            "body-only update must wake details watchers"
+        );
+
+        // A membership change still wakes the list watchers.
+        store
+            .set_folder("f", vec![stored(make_mail("l", "e2", "s2", true), 2)])
+            .await;
+        assert!(list_watch.has_changed().unwrap());
     }
 
     #[test]

--- a/crates/bridge/src/util.rs
+++ b/crates/bridge/src/util.rs
@@ -1,4 +1,4 @@
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// Lock a std `Mutex`, recovering the guard if a previous holder poisoned it by
 /// panicking. Our locked sections are short and panic-free, so this should
@@ -9,6 +9,16 @@ use std::sync::{Mutex, MutexGuard};
 /// sync for the rest of the process's life.
 pub fn lock_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
     m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// [`lock_recover`] for a std `RwLock` read guard.
+pub fn rwlock_read_recover<T>(l: &RwLock<T>) -> RwLockReadGuard<'_, T> {
+    l.read().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// [`lock_recover`] for a std `RwLock` write guard.
+pub fn rwlock_write_recover<T>(l: &RwLock<T>) -> RwLockWriteGuard<'_, T> {
+    l.write().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

The bridge grew to a 14 GB footprint (observed live, `footprint`: 10 GB MALLOC_LARGE dirty) on a 19k-mail account, with 26 CPU-minutes burned in 34 minutes of uptime. Three compounding causes:

1. Every fetched body (rendered RFC 2822 with attachments inlined as base64, plus decrypted `MailDetails`) was retained in the in-memory store forever. A client doing a full offline sync (Thunderbird "keep messages on this computer") pulled the whole mailbox into RAM.
2. Every stored body bumped the store generation, waking every idle IMAP session, and each woken session deep-cloned the selected folder to diff it: five full-mailbox clones per arriving body.
3. Startup decrypted every cached `.eml.enc` into memory (1.4 GB before even serving), and each session snapshot cloned all loaded bodies per connection.

## Changes

- **perf(store)**: body-only updates ride a dedicated `details_generation` watch that only the GUI stats watcher subscribes to. List membership changes keep the old channel; client-visible behavior is unchanged (a body landing produces no EXISTS/EXPUNGE anyway).
- **feat(mem)**: new `body_cache` module: a byte-bounded (256 MB) LRU keyed by element id. Eviction is safe because bodies are persisted encrypted on disk; a miss re-reads the `.eml.enc` on the blocking pool. `MailStore` and session snapshots are metadata-only (`body_loaded` flag). FETCH content requests go through the cache with disk fallback; decoration items (RFC822.SIZE, ENVELOPE, BODYSTRUCTURE, headers) use the warm cache only and fall back to the metadata-rendered placeholder, so list building never storms the disk. SEARCH views read the warm cache only. On-demand fetched bodies are now persisted to disk (previously RAM-only, lost on restart).

## Verification

- 283 unit tests green (new: body cache LRU/accounting/eviction/oversized-entry, generation-split watch).
- Live on a 19,868-mail account: boot footprint **197 MB** (was 14 GB scenario); a 400-body pull grows it to **290 MB, bounded**; IMAP integration suite 10/10; end-to-end realtime check (SMTP self-send → WS event → INBOX with monotonic UIDs) passes.

## Known pre-existing quirks (not addressed here)

- Two connections fetching the same uncached body still double-fetch (no single-flight); the loser logs a benign ENOENT on the tmp-rename.
- STATUS before any SELECT reports UIDNEXT 1 (session counter).