### PR TITLE
Create secret-bearing files with owner-only permissions

### DIFF
--- a/crates/bridge/src/backup.rs
+++ b/crates/bridge/src/backup.rs
@@ -82,7 +82,8 @@ pub async fn export_eml(
     output: &Path,
     mut progress: impl FnMut(&BackupProgress),
 ) -> Result<BackupStats, String> {
-    std::fs::create_dir_all(output)
+    // Backups are plaintext mail — keep the whole tree owner-only.
+    crate::fs_private::create_dir_all_private(output)
         .map_err(|e| format!("Cannot create {}: {e}", output.display()))?;
 
     let folders = backend.list_folders().await?;
@@ -90,7 +91,7 @@ pub async fn export_eml(
 
     for folder in &folders {
         let folder_dir = folder_output_dir(output, &folder.imap_path);
-        std::fs::create_dir_all(&folder_dir)
+        crate::fs_private::create_dir_all_private(&folder_dir)
             .map_err(|e| format!("Cannot create {}: {e}", folder_dir.display()))?;
         stats.folders += 1;
 
@@ -155,7 +156,8 @@ pub async fn export_eml(
                 }
             };
 
-            match tokio::task::block_in_place(|| std::fs::write(&path, eml.as_bytes())) {
+            match tokio::task::block_in_place(|| crate::fs_private::write_private(&path, eml.as_bytes()))
+            {
                 Ok(()) => {
                     stats.mails_written += 1;
                     stats.bytes += eml.len() as u64;

--- a/crates/bridge/src/backup.rs
+++ b/crates/bridge/src/backup.rs
@@ -156,8 +156,9 @@ pub async fn export_eml(
                 }
             };
 
-            match tokio::task::block_in_place(|| crate::fs_private::write_private(&path, eml.as_bytes()))
-            {
+            match tokio::task::block_in_place(|| {
+                crate::fs_private::write_private(&path, eml.as_bytes())
+            }) {
                 Ok(()) => {
                     stats.mails_written += 1;
                     stats.bytes += eml.len() as u64;

--- a/crates/bridge/src/config.rs
+++ b/crates/bridge/src/config.rs
@@ -97,6 +97,9 @@ pub fn store_mails_dir() -> PathBuf {
 pub fn load_config() -> Result<Option<Config>, Box<dyn std::error::Error>> {
     let path = config_path();
     if path.exists() {
+        // The file holds the bridge password; heal installs whose config was
+        // written before files were created owner-only.
+        crate::fs_private::tighten(&path);
         let content = std::fs::read_to_string(&path)?;
         Ok(Some(toml::from_str(&content)?))
     } else {
@@ -106,9 +109,9 @@ pub fn load_config() -> Result<Option<Config>, Box<dyn std::error::Error>> {
 
 pub fn save_config(cfg: &Config) -> Result<(), Box<dyn std::error::Error>> {
     let path = config_path();
-    std::fs::create_dir_all(path.parent().unwrap())?;
+    crate::fs_private::create_dir_all_private(path.parent().unwrap())?;
     let content = toml::to_string_pretty(cfg)?;
-    std::fs::write(&path, &content)?;
+    crate::fs_private::write_private(&path, &content)?;
     Ok(())
 }
 

--- a/crates/bridge/src/fs_private.rs
+++ b/crates/bridge/src/fs_private.rs
@@ -1,0 +1,121 @@
+//! Filesystem helpers that keep secret-bearing files private to their owner.
+//!
+//! `config.toml` (bridge password), `key.pem` (local TLS private key) and
+//! plaintext backup exports must not be readable by other local users.
+//! `std::fs::write` honours the process umask (typically 022, i.e.
+//! world-readable files), so these wrappers create files as 0600 and
+//! directories as 0700 on Unix. On other platforms they fall back to the std
+//! behaviour — Windows already scopes `%APPDATA%` to the user via ACLs.
+
+use std::path::Path;
+
+/// `std::fs::write`, but the file is created with mode 0600 on Unix. A
+/// pre-existing file has its permissions tightened to 0600 as well, so
+/// installs that predate this hardening are healed on their next write.
+pub fn write_private(
+    path: impl AsRef<Path>,
+    contents: impl AsRef<[u8]>,
+) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::fs::Permissions;
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        // `mode` only applies when the file is newly created.
+        f.set_permissions(Permissions::from_mode(0o600))?;
+        f.write_all(contents.as_ref())
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, contents)
+    }
+}
+
+/// `std::fs::create_dir_all`, but directories it creates get mode 0700 on
+/// Unix. Directories that already exist are left untouched.
+pub fn create_dir_all_private(path: impl AsRef<Path>) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
+}
+
+/// Best-effort chmod 0600 of an existing secret-bearing file. No-op on
+/// non-Unix platforms or when the file is absent. Called from load paths so
+/// files written by versions that predate [`write_private`] get fixed up.
+pub fn tighten(path: impl AsRef<Path>) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path.as_ref(), std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn mode_of(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[test]
+    fn write_private_creates_0600() {
+        let dir = std::env::temp_dir().join(format!("fs_private_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("secret.txt");
+
+        write_private(&file, "s3cret").unwrap();
+        assert_eq!(mode_of(&file), 0o600);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "s3cret");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn write_private_tightens_existing_file() {
+        let dir = std::env::temp_dir().join(format!("fs_private_test2_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("secret.txt");
+
+        std::fs::write(&file, "old").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_private(&file, "new").unwrap();
+        assert_eq!(mode_of(&file), 0o600);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "new");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn create_dir_all_private_creates_0700() {
+        let base = std::env::temp_dir().join(format!("fs_private_test3_{}", std::process::id()));
+        let nested = base.join("a").join("b");
+
+        create_dir_all_private(&nested).unwrap();
+        assert_eq!(mode_of(&nested), 0o700);
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
+}

--- a/crates/bridge/src/fs_private.rs
+++ b/crates/bridge/src/fs_private.rs
@@ -12,10 +12,7 @@ use std::path::Path;
 /// `std::fs::write`, but the file is created with mode 0600 on Unix. A
 /// pre-existing file has its permissions tightened to 0600 as well, so
 /// installs that predate this hardening are healed on their next write.
-pub fn write_private(
-    path: impl AsRef<Path>,
-    contents: impl AsRef<[u8]>,
-) -> std::io::Result<()> {
+pub fn write_private(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
     #[cfg(unix)]
     {
         use std::fs::Permissions;

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -3,6 +3,7 @@ pub mod body_cache;
 pub mod bridge;
 pub mod config;
 pub mod event_handler;
+mod fs_private;
 mod governed_client;
 pub mod imap;
 pub mod mail;

--- a/crates/bridge/src/tls.rs
+++ b/crates/bridge/src/tls.rs
@@ -25,6 +25,8 @@ pub fn load_or_create_tls_acceptor() -> Result<TlsAcceptor, Box<dyn std::error::
 
     let (cert_pem, key_pem) = if cert_file.exists() && key_file.exists() {
         log::info!("Loading TLS certificate from {}", cert_file.display());
+        // Heal installs whose key was written before it was created owner-only.
+        crate::fs_private::tighten(&key_file);
         (
             std::fs::read_to_string(&cert_file)?,
             std::fs::read_to_string(&key_file)?,
@@ -32,9 +34,9 @@ pub fn load_or_create_tls_acceptor() -> Result<TlsAcceptor, Box<dyn std::error::
     } else {
         log::info!("Generating self-signed TLS certificate...");
         let (cert, key) = generate_self_signed()?;
-        std::fs::create_dir_all(cert_dir())?;
+        crate::fs_private::create_dir_all_private(cert_dir())?;
         std::fs::write(&cert_file, &cert)?;
-        std::fs::write(&key_file, &key)?;
+        crate::fs_private::write_private(&key_file, &key)?;
         log::info!("Certificate saved to {}", cert_file.display());
         (cert, key)
     };


### PR DESCRIPTION
## What

Adds a small `fs_private` module (files created 0600, directories 0700 on Unix; plain std behaviour elsewhere) and uses it for the three secret-bearing write paths:

- `config.toml` — contains the plaintext bridge password, which is both the IMAP/SMTP credential and the MCP bearer token
- `key.pem` — the local TLS private key
- backup exports — plaintext `.eml` of the whole mailbox

The load paths (`load_config`, `load_or_create_tls_acceptor`) also do a best-effort chmod 0600 on existing files, so installs created before this change get healed on their next run without any migration step.

## Why

All of these were written with `std::fs::write`, which honours the process umask — typically 022, i.e. world-readable. On a multi-user host any other local user could read the bridge password (full mailbox access via IMAP) or the TLS key (MITM between mail client and bridge on loopback).

On non-Unix platforms the helpers fall back to plain `std::fs` behaviour; Windows already scopes `%APPDATA%` to the user via ACLs.

Includes unit tests for the created/tightened modes (Unix only).
