### PR TITLE
Keep the bridge password out of the log stream

### DIFF
--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -30,8 +30,7 @@ systemctl --user enable --now tutabridge     # run it in the background from now
 ```
 
 Connect your mail client to `127.0.0.1:1143` (IMAP) and `127.0.0.1:1025`
-(SMTP), using the bridge password printed in the logs
-(`journalctl --user -u tutabridge`).
+(SMTP), using the bridge password (`tutabridge password` prints it).
 
 ## Publishing to the AUR
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,21 @@ async fn main() -> anyhow::Result<()> {
             };
             return run_backup(output).await;
         }
+        Some("password") => {
+            let pw = config::load_config()
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .and_then(|cfg| cfg.bridge_password);
+            let Some(pw) = pw else {
+                eprintln!("No bridge password yet — run the bridge once to generate one.");
+                std::process::exit(1);
+            };
+            println!("{pw}");
+            return Ok(());
+        }
         Some("--help") | Some("-h") | Some("help") => {
             println!("tutabridge                 run the IMAP/SMTP bridge (default)");
             println!("tutabridge backup <dir>    export every mail to <dir> as .eml files");
+            println!("tutabridge password        print the local bridge password (mail client setup)");
             return Ok(());
         }
         _ => {}
@@ -54,6 +66,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
+    let bridge_password_is_new = cfg.bridge_password.is_none();
     let bridge_password = config::ensure_bridge_password(&mut cfg)
         .map_err(|e| anyhow::anyhow!("Bridge password setup failed: {e}"))?;
     info!("TutaBridge starting...");
@@ -223,8 +236,14 @@ async fn main() -> anyhow::Result<()> {
     info!("  IMAP server: 127.0.0.1:{} (SSL/TLS)", cfg.imap_port);
     info!("  SMTP server: 127.0.0.1:{} (SSL/TLS)", cfg.smtp_port);
     info!("  Username: {}", cfg.email);
-    info!("  Password: {}", bridge_password);
+    info!("  Password: ******** (run 'tutabridge password' to view)");
     info!("  Accept the self-signed certificate when prompted");
+    if bridge_password_is_new {
+        use std::io::IsTerminal;
+        if std::io::stdout().is_terminal() {
+            println!("Generated bridge password: {bridge_password}");
+        }
+    }
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,9 @@ async fn main() -> anyhow::Result<()> {
         Some("--help") | Some("-h") | Some("help") => {
             println!("tutabridge                 run the IMAP/SMTP bridge (default)");
             println!("tutabridge backup <dir>    export every mail to <dir> as .eml files");
-            println!("tutabridge password        print the local bridge password (mail client setup)");
+            println!(
+                "tutabridge password        print the local bridge password (mail client setup)"
+            );
             return Ok(());
         }
         _ => {}

--- a/tests/password_subcommand.rs
+++ b/tests/password_subcommand.rs
@@ -1,0 +1,74 @@
+//! Integration tests for `tutabridge password`.
+//!
+//! Linux-only: they steer the config directory through `XDG_CONFIG_HOME`,
+//! which the `dirs` crate honours only there.
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn run_password(config_home: &PathBuf) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_tutabridge"))
+        .arg("password")
+        .env("XDG_CONFIG_HOME", config_home)
+        .output()
+        .expect("failed to run tutabridge binary")
+}
+
+fn temp_config_home(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tutabridge_pw_{tag}_{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("tutabridge")).unwrap();
+    dir
+}
+
+#[test]
+fn prints_the_stored_password_to_stdout() {
+    let home = temp_config_home("stored");
+    std::fs::write(
+        home.join("tutabridge").join("config.toml"),
+        "email = \"test@tuta.com\"\n\
+         imap_port = 1143\n\
+         smtp_port = 1025\n\
+         bridge_password = \"AbCdE-FgHjK-mNpQr-StUvW\"\n",
+    )
+    .unwrap();
+
+    let out = run_password(&home);
+    assert!(out.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout),
+        "AbCdE-FgHjK-mNpQr-StUvW\n"
+    );
+
+    std::fs::remove_dir_all(&home).unwrap();
+}
+
+#[test]
+fn fails_when_no_password_has_been_generated() {
+    let home = temp_config_home("nopw");
+    std::fs::write(
+        home.join("tutabridge").join("config.toml"),
+        "email = \"test@tuta.com\"\n\
+         imap_port = 1143\n\
+         smtp_port = 1025\n",
+    )
+    .unwrap();
+
+    let out = run_password(&home);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(out.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("No bridge password"));
+
+    std::fs::remove_dir_all(&home).unwrap();
+}
+
+#[test]
+fn fails_when_no_config_exists() {
+    let home = temp_config_home("nocfg");
+
+    let out = run_password(&home);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(out.stdout.is_empty());
+
+    std::fs::remove_dir_all(&home).unwrap();
+}


### PR DESCRIPTION
## What

The CLI printed the bridge password at info level on every startup:

```
info!("  Password: {}", bridge_password);
```

With this change the credential never goes through the logger at all:

- The startup banner shows a fixed mask and points at a new subcommand:
  ```
    Password: ******** (run 'tutabridge password' to view)
  ```
- **`tutabridge password`** prints the password to stdout on explicit request — mail client setup, scripting — and exits non-zero with a hint if none has been generated yet.
- At **first generation** it is additionally printed once via `println!`, guarded by `is_terminal()`: interactive first-run setup still shows the password right when it's needed, while a daemonized start (stdout not a TTY, e.g. under systemd) never emits it.

This mirrors how Proton Mail Bridge handles its local credential: never logged, retrieved on demand.

## Why

Startup logs are long-lived: journald under systemd, terminal scrollback, any log shipping. The bridge password is the full-mailbox credential (IMAP/SMTP auth and the MCP bearer token), so re-printing it on every start turns it into a routine log artifact. A fixed-width mask (rather than a length-matching one) also avoids vouching for the credential's length in logs.
