### PR TITLE
Preserve plaintext bodies end-to-end and thread patch series

### DIFF
--- a/crates/bridge/src/mail/parser.rs
+++ b/crates/bridge/src/mail/parser.rs
@@ -19,6 +19,26 @@ pub struct ParsedMessage {
     pub bcc: Vec<(String, String)>,
     pub subject: String,
     pub body_html: String,
+    /// The body exactly as submitted, when the submission carried only a
+    /// text/plain body (no HTML part) — e.g. git send-email patches.
+    /// Preserved verbatim: no escaping, no wrapping, original line endings.
+    /// Tuta's outbound text/plain generation is a lossy HTML→text
+    /// conversion, so anything the send path derives from `body_html`
+    /// cannot round-trip a patch — this is the only faithful source.
+    pub body_text: Option<String>,
+    /// True when the submission carried only a text/plain body. The send
+    /// path uses this to ask the server for text/plain outbound delivery
+    /// (and sends `body_text` as the draft body so there is no HTML for
+    /// the server's converter to mangle).
+    pub is_plaintext: bool,
+    /// The submission's own `Message-ID`, without angle brackets. The send
+    /// path records the server-assigned id against it so later submissions
+    /// referencing this one (a git send-email series) can be threaded.
+    pub message_id: Option<String>,
+    /// The message this submission replies to: `In-Reply-To`, falling back
+    /// to the last id in `References` (both set by git send-email; some
+    /// MUAs only set one). Without angle brackets.
+    pub in_reply_to: Option<String>,
     pub attachments: Vec<Attachment>,
 }
 
@@ -43,22 +63,32 @@ pub fn parse_rfc2822(raw: &str) -> ParsedMessage {
         .map(|s| decode_header_value(&s))
         .unwrap_or_default();
 
+    let message_id = get_header(&headers, "message-id")
+        .as_deref()
+        .and_then(first_msg_id);
+    let in_reply_to = get_header(&headers, "in-reply-to")
+        .as_deref()
+        .and_then(first_msg_id)
+        .or_else(|| {
+            get_header(&headers, "references")
+                .as_deref()
+                .and_then(last_msg_id)
+        });
+
     let content_type = get_header(&headers, "content-type").unwrap_or_default();
     let content_transfer_encoding = get_header(&headers, "content-transfer-encoding")
         .unwrap_or_default()
         .to_lowercase();
 
-    let (body_html, attachments) = if content_type.to_lowercase().contains("multipart/") {
+    let ct_lower = content_type.to_lowercase();
+    let (body_html, attachments, body_text) = if ct_lower.contains("multipart/") {
         extract_multipart_body_and_attachments(&body_section, &content_type)
     } else {
-        (
-            decode_body(
-                &body_section,
-                &content_transfer_encoding,
-                &content_type.to_lowercase(),
-            ),
-            Vec::new(),
-        )
+        // An absent Content-Type defaults to text/plain (RFC 2045 §5.2).
+        let is_plaintext = ct_lower.is_empty() || ct_lower.contains("text/plain");
+        let decoded = decode_transfer(&body_section, &content_transfer_encoding);
+        let body_html = wrap_plain_as_html(&decoded, &ct_lower);
+        (body_html, Vec::new(), is_plaintext.then_some(decoded))
     };
 
     ParsedMessage {
@@ -69,8 +99,46 @@ pub fn parse_rfc2822(raw: &str) -> ParsedMessage {
         bcc,
         subject,
         body_html,
+        is_plaintext: body_text.is_some(),
+        body_text,
+        message_id,
+        in_reply_to,
         attachments,
     }
+}
+
+/// All RFC 5322 msg-ids in a header value, angle brackets stripped. A value
+/// with no `<...>` spans (some MUAs write bare ids) yields the trimmed value
+/// itself, if non-empty.
+fn msg_ids(raw: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    let mut rest = raw;
+    while let Some(open) = rest.find('<') {
+        let Some(close) = rest[open + 1..].find('>') else {
+            break;
+        };
+        let id = rest[open + 1..open + 1 + close].trim();
+        if !id.is_empty() {
+            ids.push(id.to_string());
+        }
+        rest = &rest[open + 1 + close + 1..];
+    }
+    if ids.is_empty() {
+        let bare = raw.trim();
+        if !bare.is_empty() {
+            ids.push(bare.to_string());
+        }
+    }
+    ids
+}
+
+fn first_msg_id(raw: &str) -> Option<String> {
+    msg_ids(raw).into_iter().next()
+}
+
+/// `References` lists oldest→newest, so the last id is the direct parent.
+fn last_msg_id(raw: &str) -> Option<String> {
+    msg_ids(raw).into_iter().next_back()
 }
 
 pub(super) fn split_headers_body(raw: &str) -> (String, String) {
@@ -264,13 +332,16 @@ pub(super) fn extract_boundary(content_type: &str) -> Option<String> {
 ///   * the user-facing HTML (or plain) body (first non-attachment text part);
 ///   * every part that looks like a file attachment (non-text, or a part
 ///     with `Content-Disposition: attachment` / a `name=` in its Content-Type).
+/// Returns `(body_html, attachments, body_text)` — `body_text` is the raw
+/// decoded text/plain body, present only when no HTML alternative existed
+/// anywhere (the submission was genuinely plaintext).
 fn extract_multipart_body_and_attachments(
     body: &str,
     content_type: &str,
-) -> (String, Vec<Attachment>) {
+) -> (String, Vec<Attachment>, Option<String>) {
     let boundary = match extract_boundary(content_type) {
         Some(b) => b,
-        None => return (body.to_string(), Vec::new()),
+        None => return (body.to_string(), Vec::new(), None),
     };
 
     let parts = split_mime_parts(body, &boundary);
@@ -293,9 +364,13 @@ fn extract_multipart_body_and_attachments(
             || (extract_param(&part_ct, "name").is_some() && !part_ct_lower.contains("text/"));
 
         if part_ct_lower.contains("multipart/") {
-            let (nested_body, nested_atts) =
+            let (nested_body, nested_atts, nested_text) =
                 extract_multipart_body_and_attachments(&part_body, &part_ct);
-            if html_part.is_none() && !nested_body.is_empty() {
+            if let Some(raw) = nested_text {
+                if text_part.is_none() {
+                    text_part = Some(raw);
+                }
+            } else if html_part.is_none() && !nested_body.is_empty() {
                 html_part = Some(nested_body);
             }
             attachments.extend(nested_atts);
@@ -328,15 +403,25 @@ fn extract_multipart_body_and_attachments(
                 data,
             });
         } else if part_ct_lower.contains("text/html") && html_part.is_none() {
-            html_part = Some(decode_body(&part_body, &part_cte, &part_ct_lower));
+            html_part = Some(decode_transfer(&part_body, &part_cte));
         } else if part_ct_lower.contains("text/plain") && html_part.is_none() && text_part.is_none()
         {
-            text_part = Some(decode_body(&part_body, &part_cte, &part_ct_lower));
+            // Raw — the `<pre>` HTML rendering is derived below only if no
+            // HTML alternative shows up in a later part.
+            text_part = Some(decode_transfer(&part_body, &part_cte));
         }
     }
 
-    let body = html_part.or(text_part).unwrap_or_else(|| body.to_string());
-    (body, attachments)
+    // Plaintext only when no HTML alternative existed anywhere: an unknown
+    // structure that falls back to the raw section is conservatively HTML.
+    match (html_part, text_part) {
+        (Some(html), _) => (html, attachments, None),
+        (None, Some(raw)) => {
+            let html = wrap_plain_as_html(&raw, "text/plain");
+            (html, attachments, Some(raw))
+        }
+        (None, None) => (body.to_string(), attachments, None),
+    }
 }
 
 /// Pull a `key=value` parameter out of a header value such as a Content-Type
@@ -401,8 +486,10 @@ pub(super) fn split_mime_parts(body: &str, boundary: &str) -> Vec<String> {
     parts
 }
 
-fn decode_body(body: &str, transfer_encoding: &str, content_type: &str) -> String {
-    let decoded = if transfer_encoding.contains("base64") {
+/// Undo the Content-Transfer-Encoding, nothing else — the result is the body
+/// exactly as the submitter wrote it.
+fn decode_transfer(body: &str, transfer_encoding: &str) -> String {
+    if transfer_encoding.contains("base64") {
         let clean: String = body.chars().filter(|c| !c.is_whitespace()).collect();
         base64::engine::general_purpose::STANDARD
             .decode(&clean)
@@ -415,12 +502,16 @@ fn decode_body(body: &str, transfer_encoding: &str, content_type: &str) -> Strin
         decode_quoted_printable(body)
     } else {
         body.to_string()
-    };
+    }
+}
 
+/// The HTML rendering of a decoded body: text/plain becomes an escaped
+/// `<pre>` block (for display in Tuta clients), anything else passes through.
+fn wrap_plain_as_html(decoded: &str, content_type: &str) -> String {
     if content_type.contains("text/plain") && !content_type.contains("text/html") {
-        format!("<pre>{}</pre>", html_escape(&decoded))
+        format!("<pre>{}</pre>", html_escape(decoded))
     } else {
-        decoded
+        decoded.to_string()
     }
 }
 
@@ -501,7 +592,7 @@ mod tests {
     fn base64_body_non_utf8_is_not_echoed_as_base64() {
         // "caf" + 0xE9 (Latin-1 'é'): valid base64, not valid UTF-8.
         let b64 = base64::engine::general_purpose::STANDARD.encode(b"caf\xe9");
-        let out = decode_body(&b64, "base64", "text/html");
+        let out = decode_transfer(&b64, "base64");
         assert!(!out.contains(&b64), "must not emit the raw base64 blob");
         assert!(
             out.starts_with("caf"),
@@ -546,6 +637,90 @@ mod tests {
         let raw = "From: a@b.com\r\nTo: b@c.com\r\nSubject: Test\r\nContent-Type: text/plain\r\n\r\nHello <world>";
         let msg = parse_rfc2822(raw);
         assert_eq!(msg.body_html, "<pre>Hello &lt;world&gt;</pre>");
+        assert!(msg.is_plaintext);
+    }
+
+    #[test]
+    fn message_id_and_in_reply_to_are_extracted_bare() {
+        let raw = "From: a@b.com\r\nMessage-ID: <20260802-1-paul@scarrone.co>\r\nIn-Reply-To: <20260802-0-paul@scarrone.co>\r\nReferences: <old@x> <20260802-0-paul@scarrone.co>\r\n\r\nbody";
+        let msg = parse_rfc2822(raw);
+        assert_eq!(
+            msg.message_id.as_deref(),
+            Some("20260802-1-paul@scarrone.co")
+        );
+        assert_eq!(
+            msg.in_reply_to.as_deref(),
+            Some("20260802-0-paul@scarrone.co")
+        );
+    }
+
+    #[test]
+    fn in_reply_to_falls_back_to_last_reference() {
+        // git send-email sets both; some MUAs only set References. The
+        // last id there is the direct parent.
+        let raw = "From: a@b.com\r\nReferences: <root@x>\r\n <parent@x>\r\n\r\nbody";
+        let msg = parse_rfc2822(raw);
+        assert_eq!(msg.in_reply_to.as_deref(), Some("parent@x"));
+    }
+
+    #[test]
+    fn bare_message_id_without_brackets_is_accepted() {
+        let raw = "From: a@b.com\r\nIn-Reply-To: bare-id@host\r\n\r\nbody";
+        let msg = parse_rfc2822(raw);
+        assert_eq!(msg.in_reply_to.as_deref(), Some("bare-id@host"));
+        assert!(msg.message_id.is_none());
+    }
+
+    #[test]
+    fn plaintext_body_is_preserved_verbatim() {
+        // The draft body sent to Tuta must be the SMTP bytes, untouched:
+        // shell metacharacters, blank lines, indentation, trailing spaces.
+        // The <pre> rendering exists alongside, not instead.
+        let body = "cmd >/dev/null 2>&1\r\nread </dev/null\r\na && b || c\r\nif [ $x -lt 5 ]; then echo \"<tag>\"; fi\r\n\r\n\tindented\r\n  two  spaces  \r\n";
+        let raw = format!(
+            "From: a@b.com\r\nTo: b@c.com\r\nSubject: probe\r\nContent-Type: text/plain\r\n\r\n{}",
+            body
+        );
+        let msg = parse_rfc2822(&raw);
+        assert!(msg.is_plaintext);
+        assert_eq!(msg.body_text.as_deref(), Some(body));
+        assert!(msg.body_html.starts_with("<pre>"));
+        assert!(msg.body_html.contains("&lt;tag&gt;"));
+    }
+
+    #[test]
+    fn plaintext_body_survives_quoted_printable() {
+        let raw = "From: a@b.com\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\ndiff --git a/x b/x\r\n-a =3D b\r\n+a < b && c\r\n";
+        let msg = parse_rfc2822(raw);
+        assert_eq!(
+            msg.body_text.as_deref(),
+            Some("diff --git a/x b/x\r\n-a = b\r\n+a < b && c\r\n")
+        );
+    }
+
+    #[test]
+    fn multipart_plain_only_preserves_raw_body_text() {
+        let raw = "From: a@b.com\r\nContent-Type: multipart/mixed; boundary=\"bnd\"\r\n\r\n--bnd\r\nContent-Type: text/plain\r\n\r\nread </dev/null\na && b\n--bnd--";
+        let msg = parse_rfc2822(raw);
+        assert!(msg.is_plaintext);
+        assert_eq!(msg.body_text.as_deref(), Some("read </dev/null\na && b\n"));
+    }
+
+    #[test]
+    fn html_alternative_clears_body_text() {
+        let raw = "From: a@b.com\r\nContent-Type: multipart/alternative; boundary=\"b\"\r\n\r\n--b\r\nContent-Type: text/plain\r\n\r\nplain\r\n--b\r\nContent-Type: text/html\r\n\r\n<p>html</p>\r\n--b--";
+        let msg = parse_rfc2822(raw);
+        assert!(!msg.is_plaintext);
+        assert!(msg.body_text.is_none());
+    }
+
+    #[test]
+    fn is_plaintext_false_for_html_and_missing_default() {
+        let html = "From: a@b.com\r\nContent-Type: text/html\r\n\r\n<p>Hi</p>";
+        assert!(!parse_rfc2822(html).is_plaintext);
+        // No Content-Type defaults to text/plain (RFC 2045 §5.2).
+        let bare = "From: a@b.com\r\n\r\nHi";
+        assert!(parse_rfc2822(bare).is_plaintext);
     }
 
     #[test]
@@ -594,6 +769,7 @@ mod tests {
         let raw = "From: a@b.com\r\nTo: b@c.com\r\nSubject: Test\r\nContent-Type: multipart/alternative; boundary=\"abc123\"\r\n\r\n--abc123\r\nContent-Type: text/plain\r\n\r\nHello plain\r\n--abc123\r\nContent-Type: text/html\r\n\r\n<p>Hello HTML</p>\r\n--abc123--";
         let msg = parse_rfc2822(raw);
         assert!(msg.body_html.contains("Hello HTML"));
+        assert!(!msg.is_plaintext);
     }
 
     #[test]
@@ -608,6 +784,7 @@ mod tests {
         let raw = "From: a@b.com\r\nTo: b@c.com\r\nSubject: Test\r\nContent-Type: multipart/alternative; boundary=\"bnd\"\r\n\r\n--bnd\r\nContent-Type: text/plain\r\n\r\nJust plain\r\n--bnd--";
         let msg = parse_rfc2822(raw);
         assert!(msg.body_html.contains("Just plain"));
+        assert!(msg.is_plaintext);
     }
 
     #[test]

--- a/crates/bridge/src/mail/rfc2822.rs
+++ b/crates/bridge/src/mail/rfc2822.rs
@@ -59,13 +59,11 @@ pub fn mail_to_rfc2822(
     let body_text = details
         .and_then(|d| d.body.compressedText.as_deref().or(d.body.text.as_deref()))
         .unwrap_or("<p>(No body available)</p>");
+    let body_plain = html_to_text(body_text);
+    let alt_boundary = build_alt_boundary(mail);
 
     if attachments.is_empty() {
-        msg.push_str("Content-Type: text/html; charset=UTF-8\r\n");
-        msg.push_str("Content-Transfer-Encoding: base64\r\n");
-        msg.push_str("\r\n");
-        msg.push_str(&base64_encode_body(body_text.as_bytes()));
-        msg.push_str("\r\n");
+        push_alternative_body(&mut msg, &alt_boundary, &body_plain, body_text);
     } else {
         // The boundary is derived from the mail's element id so the same
         // mail always produces the same MIME boundary — keeps `.eml.enc`
@@ -79,10 +77,7 @@ pub fn mail_to_rfc2822(
         msg.push_str("This is a multi-part message in MIME format.\r\n");
 
         msg.push_str(&format!("--{}\r\n", boundary));
-        msg.push_str("Content-Type: text/html; charset=UTF-8\r\n");
-        msg.push_str("Content-Transfer-Encoding: base64\r\n\r\n");
-        msg.push_str(&base64_encode_body(body_text.as_bytes()));
-        msg.push_str("\r\n");
+        push_alternative_body(&mut msg, &alt_boundary, &body_plain, body_text);
 
         for (file, data) in attachments {
             msg.push_str(&format!("--{}\r\n", boundary));
@@ -125,6 +120,125 @@ fn build_boundary(mail: &Mail) -> String {
     } else {
         "=_TutaBridge_unknown".to_owned()
     }
+}
+
+/// Boundary for the inner `multipart/alternative` part. Same stability rules
+/// as [`build_boundary`]; the `Alt` sits before the ids so neither boundary
+/// is a prefix of the other (the lenient `split_mime_parts` matches on
+/// `starts_with`, so a shared prefix would split the outer part on inner
+/// delimiters).
+fn build_alt_boundary(mail: &Mail) -> String {
+    if let Some(ref id) = mail._id {
+        format!("=_TutaBridgeAlt_{}_{}", id.list_id, id.element_id)
+    } else {
+        "=_TutaBridgeAlt_unknown".to_owned()
+    }
+}
+
+/// Write the `multipart/alternative` body — text/plain first, text/html
+/// second (RFC 2046 §5.1.4: order of increasing preference), both base64.
+fn push_alternative_body(msg: &mut String, boundary: &str, plain: &str, html: &str) {
+    msg.push_str(&format!(
+        "Content-Type: multipart/alternative; boundary=\"{}\"\r\n",
+        boundary
+    ));
+    msg.push_str("\r\n");
+    msg.push_str(&format!("--{}\r\n", boundary));
+    msg.push_str("Content-Type: text/plain; charset=UTF-8\r\n");
+    msg.push_str("Content-Transfer-Encoding: base64\r\n\r\n");
+    msg.push_str(&base64_encode_body(plain.as_bytes()));
+    msg.push_str("\r\n");
+    msg.push_str(&format!("--{}\r\n", boundary));
+    msg.push_str("Content-Type: text/html; charset=UTF-8\r\n");
+    msg.push_str("Content-Transfer-Encoding: base64\r\n\r\n");
+    msg.push_str(&base64_encode_body(html.as_bytes()));
+    msg.push_str(&format!("\r\n--{}--\r\n", boundary));
+}
+
+/// Convert a Tuta HTML body to text for the text/plain alternative part.
+///
+/// Must invert the storage encoding exactly, or `git am` breaks on received
+/// patches. Two shapes recover byte-for-byte:
+/// - escape+`<br>`, what `plaintext_to_tuta_html` writes for plaintext sends
+///   — handled by the general path below.
+/// - exactly one flat `<pre>` block of entity-escaped text, how bridge
+///   versions before the plaintext fix stored them — the fast path.
+///
+/// Anything else gets a whitespace-PRESERVING strip: `<br>` and closing
+/// block tags become newlines, script/style contents are dropped, entities
+/// are decoded. (`strip_html` is unsuitable here — it collapses whitespace
+/// for search indexing.)
+pub(crate) fn html_to_text(html: &str) -> String {
+    let trimmed = html.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if let Some(inner) = lower
+        .strip_prefix("<pre>")
+        .and_then(|r| r.strip_suffix("</pre>"))
+    {
+        // No raw '<' inside means this really is a single flat <pre> block —
+        // escaped content never contains one. Tags are ASCII, so the byte
+        // offsets found in `lower` slice `trimmed` safely.
+        if !inner.contains('<') {
+            return decode_entities(&trimmed[5..trimmed.len() - 6]);
+        }
+    }
+
+    let mut out = String::with_capacity(trimmed.len());
+    let mut chars = trimmed.chars();
+    while let Some(c) = chars.next() {
+        if c != '<' {
+            out.push(c);
+            continue;
+        }
+        let mut tag = String::new();
+        for t in chars.by_ref() {
+            if t == '>' {
+                break;
+            }
+            tag.push(t.to_ascii_lowercase());
+        }
+        let closing = tag.starts_with('/');
+        let name = tag
+            .trim_start_matches('/')
+            .split(|c: char| c.is_whitespace() || c == '/')
+            .next()
+            .unwrap_or("");
+        if !closing && matches!(name, "script" | "style") {
+            // Swallow everything until the matching closing tag.
+            let close = format!("</{name}");
+            let mut window = String::new();
+            for t in chars.by_ref() {
+                window.push(t.to_ascii_lowercase());
+                if window.ends_with(&close) {
+                    for t2 in chars.by_ref() {
+                        if t2 == '>' {
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        } else if name == "br"
+            || (closing
+                && matches!(
+                    name,
+                    "p" | "div"
+                        | "tr"
+                        | "li"
+                        | "pre"
+                        | "blockquote"
+                        | "h1"
+                        | "h2"
+                        | "h3"
+                        | "h4"
+                        | "h5"
+                        | "h6"
+                ))
+        {
+            out.push('\n');
+        }
+    }
+    decode_entities(&out)
 }
 
 pub(crate) fn format_address(addr: &MailAddress) -> String {
@@ -278,13 +392,16 @@ pub(crate) fn strip_html(html: &str) -> String {
 }
 
 fn decode_entities(s: &str) -> String {
+    // `&amp;` strictly last: decoding it earlier makes a literal `&lt;` in
+    // the source text (stored as `&amp;lt;`) collapse to `<` in a second
+    // pass — a real hazard for patches touching HTML/XML.
     s.replace("&nbsp;", " ")
-        .replace("&amp;", "&")
         .replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&quot;", "\"")
         .replace("&#39;", "'")
         .replace("&apos;", "'")
+        .replace("&amp;", "&")
 }
 
 /// Extract the readable body text from one of our own RFC 2822 messages, for
@@ -669,9 +786,28 @@ mod tests {
         assert!(rfc.contains("From: sender@tuta.com\r\n"));
         assert!(rfc.contains("To: Bob <bob@example.com>, charlie@example.com\r\n"));
         assert!(rfc.contains("Cc: Dave <dave@example.com>\r\n"));
-        // Body should be base64 of "<p>Hello World</p>"
+        // multipart/alternative with text/plain BEFORE text/html
+        assert!(rfc.contains(
+            "Content-Type: multipart/alternative; boundary=\"=_TutaBridgeAlt_list2_elem2\"\r\n"
+        ));
+        let plain_pos = rfc.find("Content-Type: text/plain").unwrap();
+        let html_pos = rfc.find("Content-Type: text/html").unwrap();
+        assert!(plain_pos < html_pos);
+        // html part is base64 of the stored body, plain part of its conversion
         let body_b64 = base64::engine::general_purpose::STANDARD.encode(b"<p>Hello World</p>");
         assert!(rfc.contains(&body_b64));
+        let plain_b64 = base64::engine::general_purpose::STANDARD.encode(b"Hello World\n");
+        assert!(rfc.contains(&plain_b64));
+        assert!(rfc.ends_with("--=_TutaBridgeAlt_list2_elem2--\r\n"));
+
+        // BODYSTRUCTURE reflects the alternative tree
+        let bs = crate::mail::bodystructure::compute_bodystructure(&rfc);
+        assert!(bs.contains("\"ALTERNATIVE\""));
+        assert!(bs.contains("\"PLAIN\""));
+        assert!(bs.contains("\"HTML\""));
+
+        // and the search indexer still finds the readable text
+        assert_eq!(extract_body_text(&rfc), "Hello World");
     }
 
     #[test]
@@ -779,8 +915,16 @@ mod tests {
             "Content-Type: multipart/mixed; boundary=\"=_TutaBridge_list_att_elem_att\""
         ));
         assert!(rfc.contains("--=_TutaBridge_list_att_elem_att\r\n"));
-        // Body part: text/html base64
+        // Body part: nested multipart/alternative (plain + html), closed
+        // before the attachment part starts.
+        assert!(rfc.contains(
+            "Content-Type: multipart/alternative; boundary=\"=_TutaBridgeAlt_list_att_elem_att\""
+        ));
+        assert!(rfc.contains("Content-Type: text/plain; charset=UTF-8\r\n"));
         assert!(rfc.contains("Content-Type: text/html; charset=UTF-8\r\n"));
+        let alt_close = rfc.find("--=_TutaBridgeAlt_list_att_elem_att--").unwrap();
+        let att_part = rfc.find("Content-Type: application/pdf").unwrap();
+        assert!(alt_close < att_part);
         let body_b64 = base64::engine::general_purpose::STANDARD.encode(b"<p>The body</p>");
         assert!(rfc.contains(&body_b64));
         // Attachment part
@@ -790,5 +934,53 @@ mod tests {
         assert!(rfc.contains(&pdf_b64));
         // Closing boundary
         assert!(rfc.ends_with("--=_TutaBridge_list_att_elem_att--\r\n"));
+
+        // BODYSTRUCTURE: mixed( alternative(plain, html), pdf )
+        let bs = crate::mail::bodystructure::compute_bodystructure(&rfc);
+        assert!(bs.contains("\"MIXED\""));
+        assert!(bs.contains("\"ALTERNATIVE\""));
+        assert!(bs.contains("\"PLAIN\""));
+        let alt_pos = bs.find("\"ALTERNATIVE\"").unwrap();
+        let pdf_pos = bs.find("\"PDF\"").unwrap();
+        assert!(alt_pos < pdf_pos);
+    }
+
+    #[test]
+    fn html_to_text_recovers_pre_wrapped_patch_exactly() {
+        // Bridge versions before the plaintext fix stored a text/plain
+        // submission as <pre>{html_escape(body)}</pre>. That mail is still
+        // in mailboxes, so the conversion back must stay byte-exact or
+        // `git am` corrupts patches containing < > &.
+        let patch = "Subject: [PATCH] fix\n\n\
+                     diff --git a/x.c b/x.c\n\
+                     -if (a < b && c > d)\n\
+                     +if (a <= b || c >= d)\n\
+                     \t\"quoted\"  double  spaces\n";
+        let escaped = patch
+            .replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;");
+        let stored = format!("<pre>{}</pre>", escaped);
+        assert_eq!(html_to_text(&stored), patch);
+    }
+
+    #[test]
+    fn html_to_text_pre_with_inner_tags_falls_through_to_strip() {
+        // Not a flat pre block — must take the lossy path, not exact recovery.
+        let html = "<pre>line one<br>line two</pre>";
+        assert_eq!(html_to_text(html), "line one\nline two\n");
+    }
+
+    #[test]
+    fn html_to_text_converts_breaks_and_blocks_to_newlines() {
+        let html = "<div>first</div><p>second<br>third</p><style>.x{}</style><script>bad()</script>tail &amp; end";
+        assert_eq!(html_to_text(html), "first\nsecond\nthird\ntail & end");
+    }
+
+    #[test]
+    fn html_to_text_preserves_whitespace() {
+        let html = "<pre>a  b\n\tc</pre>";
+        assert_eq!(html_to_text(html), "a  b\n\tc");
     }
 }

--- a/crates/bridge/src/tuta.rs
+++ b/crates/bridge/src/tuta.rs
@@ -11,9 +11,9 @@ use tutasdk::blobs::blob_facade::FileData;
 use tutasdk::crypto_entity_client::CryptoEntityClient;
 use tutasdk::entities::generated::sys::BlobReferenceTokenWrapper;
 use tutasdk::entities::generated::tutanota::{
-    AttachmentKeyData, DraftAttachment, DraftCreateData, DraftData, DraftRecipient, Mail, MailBox,
-    MailDetails, MailDetailsBlob, MailSetEntry, NewDraftAttachment, SendDraftData,
-    SendDraftParameters, TutanotaFile,
+    AttachmentKeyData, ConversationEntry, DraftAttachment, DraftCreateData, DraftData,
+    DraftRecipient, Mail, MailBox, MailDetails, MailDetailsBlob, MailSetEntry, NewDraftAttachment,
+    SendDraftData, SendDraftParameters, TutanotaFile,
 };
 use tutasdk::folder_system::{FolderSystem, MailSetKind};
 use tutasdk::services::generated::tutanota::{DraftService, SendDraftService};
@@ -150,6 +150,30 @@ const SELF_SEND_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(
 /// oldest entry is evicted regardless of TTL.
 const SELF_SEND_CACHE_MAX_ENTRIES: usize = 50;
 
+/// Tuta `ConversationType` values (see the web client's `ConversationType`
+/// enum): NEW=0, REPLY=1, FORWARD=2, UNKNOWN=3. UNKNOWN is unusable here:
+/// the send 500s for UNKNOWN with a `previousMessageId` the server can't
+/// resolve (established by probing), so unresolvable references send as
+/// NEW instead.
+const CONVERSATION_TYPE_NEW: i64 = 0;
+const CONVERSATION_TYPE_REPLY: i64 = 1;
+
+/// How long a submitted-Message-ID → server-assigned-id mapping is kept.
+/// git send-email submits a whole series within seconds; an hour covers
+/// pauses and manual resends without unbounded growth.
+const SENT_ID_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+
+/// Soft cap on remembered sent ids — a 200-patch series fits, a
+/// long-running bridge stays bounded.
+const SENT_ID_CACHE_MAX_ENTRIES: usize = 200;
+
+/// One remembered send: when it happened and the Message-ID the server
+/// assigned to the delivered mail (bare, no angle brackets).
+struct SentIdEntry {
+    stored_at: std::time::Instant,
+    tuta_message_id: String,
+}
+
 pub struct TutaSession {
     pub logged_in: Arc<LoggedInSdk>,
     pub email: String,
@@ -164,6 +188,12 @@ pub struct TutaSession {
     /// short-circuit `load_attachments` for self-sends and serve the
     /// cached bytes directly.
     self_send_cache: Arc<tokio::sync::Mutex<HashMap<String, SelfSendCacheEntry>>>,
+    /// Submitted `Message-ID` → server-assigned Message-ID, for mails sent
+    /// through this bridge. The server replaces the submitted id on
+    /// delivery, so a later submission whose `In-Reply-To` references an id
+    /// we sent (patch 2..N of a git send-email series) must be threaded
+    /// against the id the server actually delivered.
+    sent_id_cache: Arc<tokio::sync::Mutex<HashMap<String, SentIdEntry>>>,
 }
 
 impl TutaSession {
@@ -588,10 +618,18 @@ impl TutaSession {
 
         let draft_data = build_draft_data(msg, &self.email, added_attachments);
 
+        // Thread replies: a submission carrying In-Reply-To (git send-email
+        // series, MUA replies) gets its reference resolved to an id the
+        // server can act on. Unresolvable → (None, NEW), today's behavior.
+        let (previous_message_id, conversation_type) = match &msg.in_reply_to {
+            Some(irt) => self.resolve_previous_message(irt).await,
+            None => (None, CONVERSATION_TYPE_NEW),
+        };
+
         let create_data = DraftCreateData {
             _format: 0,
-            previousMessageId: None,
-            conversationType: 0,
+            previousMessageId: previous_message_id,
+            conversationType: conversation_type,
             ownerEncSessionKey: owner_enc_session_key,
             ownerKeyVersion: owner_key_version,
             draftData: draft_data,
@@ -632,6 +670,7 @@ impl TutaSession {
             draft_return.draft,
             parameters_id,
             attachment_key_data,
+            msg.is_plaintext,
         );
 
         let send_return = executor
@@ -639,6 +678,13 @@ impl TutaSession {
             .await?;
 
         log::info!("Mail sent, message_id: {}", send_return.messageId);
+
+        // Remember submitted-id → delivered-id so the next patch in a
+        // series can thread against what the server actually sent.
+        if let Some(submitted_id) = &msg.message_id {
+            self.remember_sent_message_id(submitted_id, &send_return.messageId)
+                .await;
+        }
         Ok(())
     }
 
@@ -674,6 +720,91 @@ impl TutaSession {
                 attachments,
             },
         );
+    }
+
+    /// Remember which Message-ID the server assigned to a mail we just
+    /// sent, keyed by the id the submitter used. Same soft-eviction shape
+    /// as the self-send cache.
+    async fn remember_sent_message_id(&self, submitted_id: &str, tuta_id: &str) {
+        let mut cache = self.sent_id_cache.lock().await;
+        if cache.len() >= SENT_ID_CACHE_MAX_ENTRIES && !cache.contains_key(submitted_id) {
+            if let Some(oldest_key) = cache
+                .iter()
+                .min_by_key(|(_, v)| v.stored_at)
+                .map(|(k, _)| k.clone())
+            {
+                cache.remove(&oldest_key);
+            }
+        }
+        cache.insert(
+            submitted_id.to_string(),
+            SentIdEntry {
+                stored_at: std::time::Instant::now(),
+                tuta_message_id: tuta_id.to_string(),
+            },
+        );
+    }
+
+    async fn lookup_sent_message_id(&self, submitted_id: &str) -> Option<String> {
+        let cache = self.sent_id_cache.lock().await;
+        cache
+            .get(submitted_id)
+            .filter(|e| e.stored_at.elapsed() <= SENT_ID_CACHE_TTL)
+            .map(|e| e.tuta_message_id.clone())
+    }
+
+    /// The server-known Message-ID of a mail the bridge served over IMAP,
+    /// given the `<list.elem@tutabridge.local>` id it minted for it: load
+    /// the Mail, then its ConversationEntry — `messageId` there is what
+    /// the official client passes as `previousMessageId` when replying.
+    async fn load_conversation_entry_message_id(
+        &self,
+        list_id: &str,
+        element_id: &str,
+    ) -> Result<Option<String>, ApiCallError> {
+        let Some(mail) = self.load_mail_by_id(list_id, element_id).await? else {
+            return Ok(None);
+        };
+        match self
+            .crypto_client()
+            .load::<ConversationEntry, _>(&mail.conversationEntry)
+            .await
+        {
+            Ok(ce) => Ok(Some(ce.messageId)),
+            Err(ApiCallError::ServerResponseError {
+                source: tutasdk::rest_error::HttpError::NotFoundError,
+            }) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Resolve a submission's `In-Reply-To` into `(previousMessageId,
+    /// conversationType)` for draft creation. Every failure degrades to
+    /// `(None, NEW)` — the pre-threading behavior — so a send can never
+    /// fail because of this.
+    async fn resolve_previous_message(&self, in_reply_to: &str) -> (Option<String>, i64) {
+        // A mail this bridge sent: the submitter's id was replaced on
+        // delivery, thread against the server-assigned one.
+        if let Some(tuta_id) = self.lookup_sent_message_id(in_reply_to).await {
+            return (Some(tuta_id), CONVERSATION_TYPE_REPLY);
+        }
+        // A mail this bridge served over IMAP under its own minted id:
+        // resolve the real id via the conversation entry.
+        if let Some((list_id, element_id)) = parse_bridge_local_id(in_reply_to) {
+            return match self
+                .load_conversation_entry_message_id(&list_id, &element_id)
+                .await
+            {
+                Ok(Some(mid)) => (Some(mid), CONVERSATION_TYPE_REPLY),
+                // Resolution failed — don't leak the synthetic local id
+                // upstream, it references nothing outside this bridge.
+                _ => (None, CONVERSATION_TYPE_NEW),
+            };
+        }
+        // A foreign id the server may not know, and no conversation type
+        // can safely carry it (see `CONVERSATION_TYPE_NEW` above), so keep
+        // today's unthreaded behavior rather than risk the send.
+        (None, CONVERSATION_TYPE_NEW)
     }
 
     /// Look up cached attachments for an incoming Mail whose own copy of
@@ -752,6 +883,19 @@ fn is_self_recipient(msg: &ParsedMessage, own_email: &str) -> bool {
         .chain(msg.cc.iter())
         .chain(msg.bcc.iter())
         .any(|(_, addr)| addr.to_ascii_lowercase() == me)
+}
+
+/// Split a Message-ID the bridge minted for IMAP —
+/// `<list>.<element>@tutabridge.local` (see `mail_to_rfc2822`) — back into
+/// its id tuple. Returns `None` for any other id. Tuta generated ids never
+/// contain `.`, so the first dot is the separator.
+fn parse_bridge_local_id(id: &str) -> Option<(String, String)> {
+    let rest = id.strip_suffix("@tutabridge.local")?;
+    let (list, elem) = rest.split_once('.')?;
+    if list.is_empty() || elem.is_empty() {
+        return None;
+    }
+    Some((list.to_string(), elem.to_string()))
 }
 
 /// Stable, lowercase key for the self-send cache. The Sent and Inbox
@@ -989,6 +1133,7 @@ pub async fn login_with_2fa(
                     email: cfg.email.clone(),
                     access_token,
                     self_send_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+                    sent_id_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
                 });
             }
             Err(e) => {
@@ -1069,6 +1214,7 @@ pub async fn login_with_2fa(
         email: cfg.email.clone(),
         access_token: credentials.access_token,
         self_send_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        sent_id_cache: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
     })
 }
 
@@ -1172,15 +1318,22 @@ fn build_draft_recipients(recipients: &[(String, String)]) -> Vec<DraftRecipient
 /// Mirrors the web client: the body goes into both `bodyText` and
 /// `compressedBodyText`, and empty sender/recipient names fall back to the
 /// address (an empty name makes `SendDraftService` fail).
+///
+/// A plaintext submission is stored as the reversible encoding of its raw
+/// SMTP bytes, never the `<pre>` rendering — see [`plaintext_to_tuta_html`].
 fn build_draft_data(
     msg: &ParsedMessage,
     sender_email: &str,
     added_attachments: Vec<DraftAttachment>,
 ) -> DraftData {
+    let body = match (msg.is_plaintext, &msg.body_text) {
+        (true, Some(text)) => plaintext_to_tuta_html(text),
+        _ => msg.body_html.clone(),
+    };
     DraftData {
         _id: None,
         subject: msg.subject.clone(),
-        bodyText: msg.body_html.clone(),
+        bodyText: body.clone(),
         senderMailAddress: sender_email.to_string(),
         senderName: if msg.from_name.is_empty() {
             sender_email.to_string()
@@ -1189,7 +1342,7 @@ fn build_draft_data(
         },
         confidential: false,
         method: 0,
-        compressedBodyText: Some(msg.body_html.clone()),
+        compressedBodyText: Some(body),
         toRecipients: build_draft_recipients(&msg.to),
         ccRecipients: build_draft_recipients(&msg.cc),
         bccRecipients: build_draft_recipients(&msg.bcc),
@@ -1198,6 +1351,32 @@ fn build_draft_data(
         replyTos: vec![],
         _errors: Default::default(),
     }
+}
+
+/// Encode a raw text/plain body for Tuta draft storage: escape `&` `<` `>`,
+/// then one `<br>` per newline (any convention). Nothing else — no `<pre>`,
+/// no wrapping.
+///
+/// Why this exact shape (the server is closed source; established by
+/// loopback probes against it):
+/// - Tuta stores `bodyText` verbatim, so what we write is what every later
+///   consumer reads.
+/// - With `SendDraftData.plaintext` set, the server derives the outbound
+///   text/plain by a lossy HTML→text conversion: it strips tags, decodes
+///   entities and maps `<br>`/block structure to newlines (it must — that
+///   is how plaintext-only accounts' editor HTML goes out readable). So
+///   `<pre>`-wrapped content loses all line structure, and fully-raw text
+///   loses `</dev/null`-style spans to the tag stripper. Escape+`<br>` is
+///   the unique fixed point: strip+decode is exactly its inverse.
+/// - The bridge's own IMAP rendering (`html_to_text`) inverts it the same
+///   way, so the Sent-folder text/plain part reproduces the submission.
+pub(crate) fn plaintext_to_tuta_html(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace("\r\n", "<br>")
+        .replace('\n', "<br>")
+        .replace('\r', "<br>")
 }
 
 /// Recognise the SDK error shape that means "the server returned the entity
@@ -1229,15 +1408,17 @@ fn random_custom_id(randomizer: &RandomizerFacade) -> CustomId {
 /// Build the `SendDraftData` for sending a previously created draft.
 ///
 /// The session data is mirrored into the nested `parameters` aggregate (with a
-/// generated `_id`), which the current server model reads; `plaintext` is
-/// `false` (it reflects the account's plaintext-only setting, not whether the
-/// mail is encrypted). Recipient key arrays stay empty for a non-confidential
-/// send.
+/// generated `_id`), which the current server model reads. `plaintext` asks
+/// the server to generate the outbound external mail as text/plain instead of
+/// HTML — set per-send from the submission's MIME type (the official client
+/// feeds it the account-wide `sendPlaintextOnly` setting instead). Recipient
+/// key arrays stay empty for a non-confidential send.
 fn build_send_draft_data(
     session_key_bytes: Vec<u8>,
     draft_id: IdTupleGenerated,
     parameters_id: CustomId,
     attachment_key_data: Vec<AttachmentKeyData>,
+    plaintext: bool,
 ) -> SendDraftData {
     SendDraftData {
         _format: 0,
@@ -1245,7 +1426,7 @@ fn build_send_draft_data(
         mailSessionKey: Some(session_key_bytes.clone()),
         bucketEncMailSessionKey: None,
         senderNameUnencrypted: None,
-        plaintext: false,
+        plaintext,
         calendarMethod: false,
         sessionEncEncryptionAuthStatus: None,
         sendAt: None,
@@ -1261,7 +1442,7 @@ fn build_send_draft_data(
             mailSessionKey: Some(session_key_bytes),
             bucketEncMailSessionKey: None,
             senderNameUnencrypted: None,
-            plaintext: false,
+            plaintext,
             calendarMethod: false,
             sessionEncEncryptionAuthStatus: None,
             mail: draft_id,
@@ -1286,6 +1467,10 @@ mod self_send_cache_tests {
             bcc: vec![],
             subject: subject.to_string(),
             body_html: "<p>body</p>".to_string(),
+            body_text: None,
+            message_id: None,
+            in_reply_to: None,
+            is_plaintext: false,
             attachments: vec![],
         }
     }
@@ -1397,6 +1582,10 @@ mod send_tests {
             bcc: vec![],
             subject: "Hi".to_string(),
             body_html: "<p>hello</p>".to_string(),
+            body_text: None,
+            message_id: None,
+            in_reply_to: None,
+            is_plaintext: false,
             attachments: vec![],
         }
     }
@@ -1408,6 +1597,41 @@ mod send_tests {
         assert_eq!(d.compressedBodyText.as_deref(), Some("<p>hello</p>"));
         assert!(!d.confidential);
         assert_eq!(d.method, 0);
+    }
+
+    #[test]
+    fn draft_data_encodes_plaintext_submissions_reversibly() {
+        // Neither the <pre> rendering nor the raw bytes may reach the
+        // server: the outbound converter collapses <pre> newlines and eats
+        // raw `</dev/null ... <tag>` spans as markup. Only escape+<br>
+        // survives strip+decode.
+        let mut msg = sample_msg();
+        msg.is_plaintext = true;
+        msg.body_text = Some("read </dev/null\r\na && b\n".to_string());
+        msg.body_html = "<pre>ignored</pre>".to_string();
+        let d = build_draft_data(&msg, "me@tuta.io", vec![]);
+        assert_eq!(d.bodyText, "read &lt;/dev/null<br>a &amp;&amp; b<br>");
+        assert_eq!(d.compressedBodyText.as_deref(), Some(d.bodyText.as_str()));
+    }
+
+    #[test]
+    fn bridge_local_id_parses_and_rejects() {
+        assert_eq!(
+            parse_bridge_local_id("Lst-1.Elem_2@tutabridge.local"),
+            Some(("Lst-1".to_string(), "Elem_2".to_string()))
+        );
+        assert_eq!(parse_bridge_local_id("20260802.1234@scarrone.co"), None);
+        assert_eq!(parse_bridge_local_id("no-dot@tutabridge.local"), None);
+        assert_eq!(parse_bridge_local_id(".x@tutabridge.local"), None);
+    }
+
+    #[test]
+    fn plaintext_encoding_round_trips_through_html_to_text() {
+        // The bridge's own receive-side conversion must invert the storage
+        // encoding exactly (modulo CRLF→LF, which the encoding folds).
+        let patch = "diff --git a/x.c b/x.c\n-if (a < b && c > d)\n+while (p != NULL)\n\t\"quoted\"  two  spaces\n";
+        let stored = plaintext_to_tuta_html(patch);
+        assert_eq!(crate::mail::rfc2822::html_to_text(&stored), patch);
     }
 
     #[test]
@@ -1445,7 +1669,7 @@ mod send_tests {
         );
         let pid = CustomId("aggId".to_string());
         let sk = vec![1u8, 2, 3, 4];
-        let sd = build_send_draft_data(sk.clone(), draft_id.clone(), pid.clone(), vec![]);
+        let sd = build_send_draft_data(sk.clone(), draft_id.clone(), pid.clone(), vec![], false);
 
         // top-level
         assert!(!sd.plaintext);
@@ -1462,5 +1686,17 @@ mod send_tests {
         assert!(!p.plaintext);
         assert_eq!(p.mailSessionKey.as_deref(), Some(sk.as_slice()));
         assert_eq!(p.mail, draft_id);
+    }
+
+    #[test]
+    fn send_draft_data_plaintext_flag_set_in_both_places() {
+        let draft_id = IdTupleGenerated::new(
+            tutasdk::GeneratedId("list".to_string()),
+            tutasdk::GeneratedId("elem".to_string()),
+        );
+        let pid = CustomId("aggId".to_string());
+        let sd = build_send_draft_data(vec![1u8], draft_id, pid, vec![], true);
+        assert!(sd.plaintext);
+        assert!(sd.parameters.expect("parameters must be set").plaintext);
     }
 }


### PR DESCRIPTION
## What

Makes the bridge usable for plaintext mail workflows (`git send-email` patch series being the motivating case). Three related changes:

**Outbound** — a text/plain-only submission keeps its body exactly as submitted (`ParsedMessage.body_text`, verbatim bytes) and the send sets `plaintext` on `SendDraftData`/`SendDraftParameters` — the per-send switch the official client feeds from the account-wide `sendPlaintextOnly` setting. The draft body is stored in a minimal reversible encoding: escape `&` `<` `>`, one `<br>` per newline.

**Inbound** — fetched mail renders over IMAP as `multipart/alternative` (text/plain + text/html), nested under `multipart/mixed` when attachments are present. The plain part comes from a new whitespace-preserving `html_to_text`.

**Threading** — `Message-ID` and `In-Reply-To` (falling back to the last `References` id) are parsed from submissions, and sends are threaded through `previousMessageId` + `ConversationType`.

## Why

Both directions previously forced HTML.

Outbound, a text/plain-only submission was stored as an escaped `<pre>` block and sent with `plaintext=false`, so external recipients got HTML. Setting the flag alone is not enough: the server's outbound HTML→text conversion collapses every newline and eats `</dev/null`-style spans as markup, silently corrupting delivered patches. Tuta stores `bodyText` verbatim, and that converter's strip-tags + decode-entities + `<br>`-to-newline is exactly the escape+`<br>` encoding in reverse — both `<pre>`-wrapped and fully-raw bodies are corrupted by it, so this encoding is the fixed point.

Inbound, every mail was rendered as a single `text/html` part, so a patch containing `< > &` arrived entity-escaped and no longer applied with `git am`.

For threading, `previousMessageId` was hardcoded `None` and the server replaces submitted `Message-ID`s, so a series arrived as N unrelated threads and sr.ht never grouped it into a patchset. The bridge now remembers submitted-id → server-assigned-id per send in a bounded TTL cache (1h, 200 entries) so patch 2..N threads against what the server actually delivered, and resolves replies to bridge-served mail (`<list.elem@tutabridge.local>`) through the mail's `ConversationEntry` — what the official client passes when replying.

## Verification

- 299 unit tests pass; `cargo fmt` clean.
- Loopback probe: a body with `</dev/null`, `<tag>`, tabs, runs of spaces and a literal `&lt;entity&gt;` round-trips byte-identically through draft storage and back out of the bridge's IMAP text/plain part.
- Live end-to-end against a sr.ht mailing list: a 5-message series (cover + 4 patches) was delivered as a single thread, with `In-Reply-To`/`References` on each patch set to the cover's server-assigned id; sr.ht grouped it as one patchset; `git am` applied all four with an empty resulting diff. The same series before this change produced 5 unrelated threads and an empty patches tab.

## Notes for review

- **Unresolvable references degrade, never fail.** An `In-Reply-To` the server cannot resolve sends as `ConversationType` NEW (unthreaded), matching today's behavior. `UNKNOWN` is deliberately unused: the send 500s for `UNKNOWN` with a `previousMessageId` the server can't resolve.
- **Entity decoding orders `&amp;` last**, so a literal `&lt;` in source text (stored as `&amp;lt;`) survives a single decode pass instead of collapsing to `<`.
- **The inner MIME boundary shares no prefix with the outer one.** `split_mime_parts` matches boundaries with `starts_with`, so a shared prefix would split the outer part on inner delimiters. Both are still derived from the mail id, which keeps `.eml.enc` bytes stable.
- **Backward compatible with already-stored mail.** A body that is exactly one flat `<pre>` block — how older bridge versions stored plaintext sends — is still recovered byte-exactly.
- The server is closed source, so the storage/conversion behaviour above was established by probing a live account rather than from documentation.
