### PR TITLE
Warn about Reply-To instead of sending a field the server drops

### DIFF
--- a/crates/bridge/src/mail/parser.rs
+++ b/crates/bridge/src/mail/parser.rs
@@ -17,10 +17,11 @@ pub struct ParsedMessage {
     pub to: Vec<(String, String)>,
     pub cc: Vec<(String, String)>,
     pub bcc: Vec<(String, String)>,
-    /// `Reply-To`, when the submission set one. Carried through to
-    /// `DraftData.replyTos` so a reply goes where the sender asked rather
-    /// than to the bridge account -- which is the only route back to a
-    /// non-bridge address when the account cannot send as one.
+    /// `Reply-To`, when the submission set one. Parsed but NOT sent: Tuta
+    /// drops `DraftData.replyTos` (see `tuta::build_draft_data`), so the send
+    /// path logs a warning instead, rather than losing the submitter's intent
+    /// in silence. Kept so that warning can name the addresses, and so the
+    /// field is ready if Tuta ever carries it.
     pub reply_to: Vec<(String, String)>,
     pub subject: String,
     pub body_html: String,
@@ -64,8 +65,7 @@ pub fn parse_rfc2822(raw: &str) -> ParsedMessage {
         .map(|v| parse_address_list(&v))
         .unwrap_or_default();
     // A list, not a single address: RFC 5322 §3.6.2 makes Reply-To an
-    // address-list, and `DraftData.replyTos` is a `Vec` for the same
-    // reason.
+    // address-list.
     let reply_to = get_header(&headers, "reply-to")
         .map(|v| parse_address_list(&v))
         .unwrap_or_default();
@@ -687,8 +687,8 @@ mod tests {
 
     #[test]
     fn reply_to_is_an_address_list() {
-        // RFC 5322 §3.6.2 makes this a list, and `DraftData.replyTos` is a
-        // Vec for the same reason -- so a second address must not be lost.
+        // RFC 5322 §3.6.2 makes this a list, so a second address must not
+        // be lost from the warning the send path logs.
         let raw = "From: a@b.com\r\nReply-To: one@x.com, Two <two@x.com>\r\n\r\nbody";
         let msg = parse_rfc2822(raw);
         assert_eq!(msg.reply_to.len(), 2);

--- a/crates/bridge/src/tuta.rs
+++ b/crates/bridge/src/tuta.rs
@@ -12,8 +12,8 @@ use tutasdk::crypto_entity_client::CryptoEntityClient;
 use tutasdk::entities::generated::sys::BlobReferenceTokenWrapper;
 use tutasdk::entities::generated::tutanota::{
     AttachmentKeyData, ConversationEntry, DraftAttachment, DraftCreateData, DraftData,
-    DraftRecipient, EncryptedMailAddress, Mail, MailBox, MailDetails, MailDetailsBlob,
-    MailSetEntry, NewDraftAttachment, SendDraftData, SendDraftParameters, TutanotaFile,
+    DraftRecipient, Mail, MailBox, MailDetails, MailDetailsBlob, MailSetEntry, NewDraftAttachment,
+    SendDraftData, SendDraftParameters, TutanotaFile,
 };
 use tutasdk::folder_system::{FolderSystem, MailSetKind};
 use tutasdk::services::generated::tutanota::{DraftService, SendDraftService};
@@ -666,6 +666,25 @@ impl TutaSession {
                 &randomizer,
             )
             .await?;
+
+        // Tuta cannot carry a Reply-To on an outgoing mail (see
+        // `build_draft_data`), so say so rather than dropping it silently: the
+        // submitter asked for replies to go somewhere and they will not.
+        // Skip blank addresses so a malformed header (`Reply-To: <>`) does not
+        // produce a warning about nothing.
+        let asked: Vec<&str> = msg
+            .reply_to
+            .iter()
+            .map(|(_, addr)| addr.trim())
+            .filter(|addr| !addr.is_empty())
+            .collect();
+        if !asked.is_empty() {
+            log::warn!(
+                "dropping Reply-To [{}]: Tuta does not support it on outgoing mail, replies will go to {}",
+                asked.join(", "),
+                sender_email
+            );
+        }
 
         let draft_data = build_draft_data(msg, &sender_email, added_attachments);
 
@@ -1348,25 +1367,6 @@ fn delete_credentials(email: &str) {
 
 /// Map SMTP recipients to `DraftRecipient`, falling back to the address when
 /// the display name is empty (Tuta's send service rejects empty names).
-/// `Reply-To` addresses for the draft. Same empty-name rule as
-/// [`build_draft_recipients`] -- `SendDraftService` rejects an empty name
-/// on an address, so the address stands in for it.
-fn build_reply_tos(reply_to: &[(String, String)]) -> Vec<EncryptedMailAddress> {
-    reply_to
-        .iter()
-        .map(|(name, addr)| EncryptedMailAddress {
-            _id: None,
-            name: if name.is_empty() {
-                addr.clone()
-            } else {
-                name.clone()
-            },
-            address: addr.clone(),
-            _errors: Default::default(),
-        })
-        .collect()
-}
-
 fn build_draft_recipients(recipients: &[(String, String)]) -> Vec<DraftRecipient> {
     recipients
         .iter()
@@ -1418,7 +1418,12 @@ fn build_draft_data(
         bccRecipients: build_draft_recipients(&msg.bcc),
         addedAttachments: added_attachments,
         removedAttachments: vec![],
-        replyTos: build_reply_tos(&msg.reply_to),
+        // Always empty: the server drops this field. Probing a live account
+        // showed a submitted `replyTos` comes back empty on the stored mail,
+        // no `Reply-To:` header reaches an external recipient, and the
+        // official client's Reply button falls through to the sender. See
+        // `send_mail_impl`, which warns instead of pretending it worked.
+        replyTos: vec![],
         _errors: Default::default(),
     }
 }
@@ -1707,29 +1712,23 @@ mod send_tests {
     }
 
     #[test]
-    fn draft_data_carries_reply_to() {
+    fn draft_data_never_sends_reply_tos() {
+        // Deliberate: the server drops `DraftData.replyTos` (a submitted value
+        // comes back empty on the stored mail, no `Reply-To:` header reaches an
+        // external recipient, and the official client's Reply button falls
+        // through to the sender). Filling it in only creates the illusion of a
+        // working feature, so the parsed Reply-To is warned about instead. This
+        // guards against re-adding the plumbing.
         let mut msg = sample_msg();
-        msg.reply_to = vec![("Paul".to_string(), "paul@scarrone.co".to_string())];
+        msg.reply_to = vec![
+            ("Paul".to_string(), "paul@scarrone.co".to_string()),
+            (String::new(), "other@example.com".to_string()),
+        ];
         let d = build_draft_data(&msg, "me@tuta.io", vec![]);
-        assert_eq!(d.replyTos.len(), 1);
-        assert_eq!(d.replyTos[0].address, "paul@scarrone.co");
-        assert_eq!(d.replyTos[0].name, "Paul");
-    }
-
-    #[test]
-    fn draft_data_reply_to_empty_name_falls_back_to_address() {
-        // `SendDraftService` rejects an empty name on an address, the same
-        // rule `build_draft_recipients` already follows.
-        let mut msg = sample_msg();
-        msg.reply_to = vec![("".to_string(), "paul@scarrone.co".to_string())];
-        let d = build_draft_data(&msg, "me@tuta.io", vec![]);
-        assert_eq!(d.replyTos[0].name, "paul@scarrone.co");
-    }
-
-    #[test]
-    fn draft_data_without_reply_to_sends_none() {
-        let d = build_draft_data(&sample_msg(), "me@tuta.io", vec![]);
-        assert!(d.replyTos.is_empty());
+        assert!(
+            d.replyTos.is_empty(),
+            "replyTos must stay empty; the server ignores it"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #22. Tuta ignores `DraftData.replyTos` on send, so filling it in only made the feature look implemented.

## How this was established

Probing a live account:

- a submitted `replyTos` comes back **empty on the stored mail**, so the field is dropped at ingest rather than merely left out of the MIME headers;
- **no `Reply-To:` header reaches an external recipient** (checked in the raw source at the receiving end), with or without a generated aggregate `_id`;
- the **official Tuta client's Reply button** on the delivered copy targets the `From:`, which per `MailViewerViewModel` is the branch taken only when `replyTos` is empty.

It is not an SDK fault: the Rust SDK encrypts nested aggregates correctly and generates aggregate ids exactly like the official client (4 random bytes, base64url). Nor is it something we are failing to configure. Tuta has no way to set an outgoing Reply-To at all:

- the composer has only To/Cc/Bcc, and `SendMailModel` has no setter;
- `replyTo_label` appears once in their entire codebase, read-only, in the mail viewer;
- every call site that composes a new mail passes an empty list;
- their own `.eml` export omits the header (asserted by an exact-match test);
- the type model marks `EncryptedMailAddress.address` encrypted while every address the server needs for delivery is explicitly unencrypted, and `DraftData.replyTos` is field 819, appended long after the type was designed. Its sibling `ImportMailData.replyTos` suggests the field exists for their mail importer.

## Changes

- Drop `build_reply_tos` and always send `replyTos: vec![]`, with the reasoning recorded at both sites.
- Warn when a submission carries a Reply-To we cannot honour, naming the addresses and where replies will actually go. Silently substituting is what makes this class of bug impossible to diagnose from the outside, which is the same argument #22 makes for its sender fallback. Blank addresses are skipped so a malformed `Reply-To: <>` does not warn about nothing.
- Keep the parsing: it names the addresses in that warning, and the field is ready if Tuta ever carries it.
- Replace the three draft-plumbing tests with a regression guard against re-adding it. The parsing tests from #22 stay.
- Restore the `build_draft_recipients` doc comment, orphaned by #22.

## Not addressed here

The **receive** direction is a real gap. Tuta does store the Reply-To of incoming mail, verified on live mail from Uber and Kraken (both reply to a different address than they send from), and the bridge never emits it over IMAP, so replying from a mail client goes to the wrong place. Separate change.

## Verification

309 unit tests, `cargo fmt --check` clean on all three crates, no new clippy warnings. Verified live: a send carrying a Reply-To warns once and still delivers, a send without one warns not at all, an alias sender still goes out as the alias, and malformed headers (`Reply-To:` empty, garbage, `<>`) neither warn spuriously nor panic.