### PR TITLE
Serve the Reply-To of received mail

### DIFF
--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -4,7 +4,9 @@ use tutasdk::entities::generated::tutanota::{Mail, MailAddress, MailDetails, Tut
 
 use crate::imap::search::{self, MsgView};
 use crate::mail::mail_to_rfc2822;
-use crate::mail::rfc2822::{extract_headers, format_address, format_internal_date};
+use crate::mail::rfc2822::{
+    extract_headers, format_address, format_internal_date, reply_to_addresses,
+};
 use crate::store::LocalStore;
 use crate::sync::MailStore;
 use crate::tuta::{FolderInfo, MailBackend};
@@ -1097,7 +1099,20 @@ fn build_envelope(cached: &CachedMail, details: Option<&MailDetails>) -> String 
         .unwrap_or_default();
     let msg_id = imap_string(&msg_id);
 
-    format!("(\"{date}\" {subject} ({from}) ({from}) ({from}) ({to}) NIL NIL NIL {msg_id})")
+    // RFC 3501 §7.4.2: the reply-to slot carries the message's Reply-To, and
+    // falls back to From only when the header is absent. Same addresses as
+    // the `Reply-To:` line rendered in the RFC 2822 message.
+    let reply_to = details
+        .map(|d| {
+            reply_to_addresses(d)
+                .map(|(name, address)| format_envelope_mailbox(name, address))
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| from.clone());
+
+    format!("(\"{date}\" {subject} ({from}) ({from}) ({reply_to}) ({to}) NIL NIL NIL {msg_id})")
 }
 
 /// Encode a string as an IMAP nstring. Safe 7-bit text becomes a quoted string;
@@ -1118,11 +1133,16 @@ fn imap_string(s: &str) -> String {
 }
 
 fn format_envelope_addr(addr: &tutasdk::entities::generated::tutanota::MailAddress) -> String {
-    let (user, domain) = addr.address.split_once('@').unwrap_or((&addr.address, ""));
-    let name = if addr.name.is_empty() {
+    format_envelope_mailbox(&addr.name, &addr.address)
+}
+
+/// One ENVELOPE address structure: `(name NIL mailbox host)`.
+fn format_envelope_mailbox(name: &str, address: &str) -> String {
+    let (user, domain) = address.split_once('@').unwrap_or((address, ""));
+    let name = if name.is_empty() {
         "NIL".to_string()
     } else {
-        imap_string(&addr.name)
+        imap_string(name)
     };
     format!(
         "({} NIL {} {})",
@@ -1404,6 +1424,46 @@ mod tests {
             !env.contains("\"La"),
             "subject must not be a quoted string holding the newline: {env}"
         );
+    }
+
+    #[test]
+    fn build_envelope_reply_to_slot_carries_the_header() {
+        use tutasdk::entities::generated::tutanota::EncryptedMailAddress;
+
+        let mut details = make_details("<p>b</p>");
+        details.replyTos = vec![
+            EncryptedMailAddress {
+                _id: None,
+                name: "Support".to_string(),
+                address: " help@replies.example.com ".to_string(),
+                _errors: Default::default(),
+            },
+            EncryptedMailAddress {
+                _id: None,
+                name: String::new(),
+                address: String::new(),
+                _errors: Default::default(),
+            },
+        ];
+        let env = build_envelope(&make_test_mail(1, "Receipt", false), Some(&details));
+        let from = "((\"Sender\" NIL \"sender\" \"tuta.com\"))";
+        let reply_to = "((\"Support\" NIL \"help\" \"replies.example.com\"))";
+        assert!(
+            env.contains(&format!("{from} {from} {reply_to} ((")),
+            "from, sender, then reply-to: {env}"
+        );
+    }
+
+    #[test]
+    fn build_envelope_reply_to_slot_falls_back_to_from() {
+        // RFC 3501 §7.4.2: without a Reply-To header the slot repeats From,
+        // whether details are missing or carry no reply-to at all.
+        let from = "((\"Sender\" NIL \"sender\" \"tuta.com\"))";
+        let cold = build_envelope(&make_test_mail(1, "Receipt", false), None);
+        assert!(cold.contains(&format!("{from} {from} {from} ")), "{cold}");
+        let details = make_details("<p>b</p>");
+        let warm = build_envelope(&make_test_mail(1, "Receipt", false), Some(&details));
+        assert!(warm.contains(&format!("{from} {from} {from} ")), "{warm}");
     }
 
     // --- parse_command ---
@@ -2529,6 +2589,47 @@ mod tests {
             .handle_command(r#"A006 SEARCH SUBJECT "nonexistent""#)
             .await;
         assert_eq!(resp[0], "* SEARCH \r\n");
+    }
+
+    #[tokio::test]
+    async fn test_search_header_reply_to_on_warm_body() {
+        use tutasdk::entities::generated::tutanota::EncryptedMailAddress;
+
+        let m1 = make_mail("m1", "Receipt", false);
+        let m2 = make_mail("m2", "Newsletter", false);
+        let mut d1 = make_details("<p>Body 1</p>");
+        d1.replyTos = vec![EncryptedMailAddress {
+            _id: None,
+            name: String::new(),
+            address: "no-reply@replies.uber.com".to_string(),
+            _errors: Default::default(),
+        }];
+        let d2 = make_details("<p>Body 2</p>");
+
+        let backend = Arc::new(MockBackend::with_mails(vec![m1.clone(), m2.clone()]));
+        let (store, mut session) = make_session(backend).await;
+        for (id, mail, details) in [("m1", &m1, d1), ("m2", &m2, d2)] {
+            let rfc2822 = crate::mail::mail_to_rfc2822(mail, Some(&details), &[]);
+            store.bodies().insert(
+                id,
+                crate::body_cache::BodyEntry {
+                    details: Some(details),
+                    rfc2822,
+                },
+            );
+        }
+        session.handle_command("A001 LOGIN user pass").await;
+        session.handle_command("A002 SELECT INBOX").await;
+
+        // Only the mail carrying a Reply-To matches, by value or by presence.
+        let resp = session
+            .handle_command(r#"A003 SEARCH HEADER Reply-To "replies.uber.com""#)
+            .await;
+        assert_eq!(resp[0], "* SEARCH 1\r\n");
+        let resp = session
+            .handle_command(r#"A004 SEARCH HEADER Reply-To """#)
+            .await;
+        assert_eq!(resp[0], "* SEARCH 1\r\n");
     }
 
     #[tokio::test]

--- a/crates/bridge/src/mail/rfc2822.rs
+++ b/crates/bridge/src/mail/rfc2822.rs
@@ -43,6 +43,18 @@ pub fn mail_to_rfc2822(
         if !cc_addrs.is_empty() {
             msg.push_str(&format!("Cc: {}\r\n", cc_addrs.join(", ")));
         }
+
+        // Received mail may carry a Reply-To: transactional senders use it to
+        // route replies away from the no-reply address they send from. Tuta
+        // keeps it in `replyTos`, so emit it or the client replies to `From:`,
+        // i.e. to the wrong place. Rendered through the same helper as To/Cc
+        // so the three headers cannot drift apart.
+        let reply_tos: Vec<String> = reply_to_addresses(details)
+            .map(|(name, address)| format_name_and_address(name, address))
+            .collect();
+        if !reply_tos.is_empty() {
+            msg.push_str(&format!("Reply-To: {}\r\n", reply_tos.join(", ")));
+        }
     } else if let Some(ref first) = mail.firstRecipient {
         msg.push_str(&format!("To: {}\r\n", format_address(first)));
     }
@@ -241,11 +253,29 @@ pub(crate) fn html_to_text(html: &str) -> String {
     decode_entities(&out)
 }
 
+/// The `(name, address)` pairs of a received mail's Reply-To, addresses
+/// trimmed and blank entries dropped. The `Reply-To:` header and the IMAP
+/// ENVELOPE both read this, so they cannot disagree on what counts as an
+/// address.
+pub(crate) fn reply_to_addresses(details: &MailDetails) -> impl Iterator<Item = (&str, &str)> {
+    details
+        .replyTos
+        .iter()
+        .map(|a| (a.name.as_str(), a.address.trim()))
+        .filter(|(_, address)| !address.is_empty())
+}
+
 pub(crate) fn format_address(addr: &MailAddress) -> String {
-    if addr.name.is_empty() {
-        addr.address.clone()
+    format_name_and_address(&addr.name, &addr.address)
+}
+
+/// `Name <addr>` when there is a display name, the bare address otherwise.
+/// Single rendering for every address-bearing header we emit.
+fn format_name_and_address(name: &str, address: &str) -> String {
+    if name.is_empty() {
+        address.to_string()
     } else {
-        format!("{} <{}>", encode_header_value(&addr.name), addr.address)
+        format!("{} <{}>", encode_header_value(name), address)
     }
 }
 
@@ -688,6 +718,161 @@ mod tests {
         assert!(rfc.contains("Message-ID: <"));
         // Body should be base64 of "<p>(No body available)</p>"
         assert!(rfc.contains("\r\n\r\n"));
+    }
+
+    // --- Reply-To on received mail ---
+
+    /// A received mail with the given `(name, address)` reply-to entries.
+    fn mail_with_reply_tos(pairs: &[(&str, &str)]) -> (Mail, MailDetails) {
+        use tutasdk::date::DateTime;
+        use tutasdk::entities::generated::tutanota::{Body, EncryptedMailAddress, Recipients};
+        use tutasdk::IdTupleGenerated;
+
+        let mail = Mail {
+            _id: Some(IdTupleGenerated::new(test_id("rlist"), test_id("relem"))),
+            _permissions: test_id("rperm"),
+            _format: 0,
+            _ownerEncSessionKey: None,
+            subject: "Receipt".to_string(),
+            receivedDate: DateTime::from_millis(0),
+            state: 2,
+            unread: false,
+            confidential: false,
+            replyType: 0,
+            _ownerGroup: None,
+            differentEnvelopeSender: None,
+            listUnsubscribe: false,
+            movedTime: None,
+            phishingStatus: 0,
+            authStatus: None,
+            method: 0,
+            recipientCount: 1,
+            encryptionAuthStatus: None,
+            _ownerKeyVersion: None,
+            processingState: 0,
+            processNeeded: false,
+            sendAt: None,
+            serverClassificationData: None,
+            _kdfNonce: None,
+            sender: MailAddress {
+                _id: None,
+                name: String::new(),
+                address: "noreply@uber.com".to_string(),
+                contact: None,
+                _errors: Default::default(),
+            },
+            attachments: vec![],
+            conversationEntry: IdTupleGenerated::new(test_id("rclist"), test_id("rcelem")),
+            firstRecipient: None,
+            mailDetails: None,
+            mailDetailsDraft: None,
+            bucketKey: None,
+            sets: vec![],
+            clientSpamClassifierResult: None,
+            _errors: Default::default(),
+        };
+
+        let details = MailDetails {
+            _id: None,
+            sentDate: DateTime::from_millis(0),
+            authStatus: 0,
+            replyTos: pairs
+                .iter()
+                .map(|(name, address)| EncryptedMailAddress {
+                    _id: None,
+                    name: (*name).to_string(),
+                    address: (*address).to_string(),
+                    _errors: Default::default(),
+                })
+                .collect(),
+            recipients: Recipients {
+                _id: None,
+                toRecipients: vec![MailAddress {
+                    _id: None,
+                    name: String::new(),
+                    address: "me@tuta.io".to_string(),
+                    contact: None,
+                    _errors: Default::default(),
+                }],
+                ccRecipients: vec![],
+                bccRecipients: vec![],
+            },
+            headers: None,
+            body: Body {
+                _id: None,
+                text: Some("<p>body</p>".to_string()),
+                compressedText: None,
+                _errors: Default::default(),
+            },
+        };
+        (mail, details)
+    }
+
+    /// The whole `Reply-To:` line, or `None` when the header is absent.
+    fn reply_to_line(pairs: &[(&str, &str)]) -> Option<String> {
+        let (mail, details) = mail_with_reply_tos(pairs);
+        let rfc = mail_to_rfc2822(&mail, Some(&details), &[]);
+        rfc.split("\r\n")
+            .find(|l| l.starts_with("Reply-To:"))
+            .map(|l| l.to_string())
+    }
+
+    #[test]
+    fn reply_to_without_a_display_name_is_the_bare_address() {
+        // The real-world shape: Uber and Kraken send from a no-reply address
+        // and set a Reply-To with no display name.
+        assert_eq!(
+            reply_to_line(&[("", "no-reply@replies.uber.com")]),
+            Some("Reply-To: no-reply@replies.uber.com".to_string())
+        );
+    }
+
+    #[test]
+    fn reply_to_with_a_display_name_keeps_it() {
+        assert_eq!(
+            reply_to_line(&[("Support", "help@example.com")]),
+            Some("Reply-To: Support <help@example.com>".to_string())
+        );
+    }
+
+    #[test]
+    fn reply_to_non_ascii_display_name_is_an_encoded_word() {
+        assert_eq!(
+            reply_to_line(&[("Réponses", "help@example.com")]),
+            Some("Reply-To: =?UTF-8?B?UsOpcG9uc2Vz?= <help@example.com>".to_string())
+        );
+    }
+
+    #[test]
+    fn several_reply_tos_are_joined() {
+        assert_eq!(
+            reply_to_line(&[("One", "one@x.com"), ("", "two@x.com")]),
+            Some("Reply-To: One <one@x.com>, two@x.com".to_string())
+        );
+    }
+
+    #[test]
+    fn no_reply_tos_emits_no_header() {
+        // Absent must stay absent: no empty header, and no echoing the sender.
+        assert_eq!(reply_to_line(&[]), None);
+    }
+
+    #[test]
+    fn blank_reply_to_addresses_are_skipped() {
+        assert_eq!(
+            reply_to_line(&[("Ghost", "   "), ("Real", "real@x.com")]),
+            Some("Reply-To: Real <real@x.com>".to_string())
+        );
+    }
+
+    #[test]
+    fn padded_reply_to_address_is_trimmed() {
+        // Whitespace around the address would otherwise land inside the angle
+        // brackets and give the client an unparseable mailbox.
+        assert_eq!(
+            reply_to_line(&[("Support", "  help@x.com ")]),
+            Some("Reply-To: Support <help@x.com>".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Transactional senders route replies away from the address they send from. Kraken mails from `no-reply@email.kraken.com` and ask for replies at `noreply@marketing.kraken.com`; verified on live mail. Tuta keeps that address in `MailDetails.replyTos` and uses it when you reply, but the bridge never emitted the header, so a mail client replying to such a mail answered `From:` instead.

## Change

Emit `Reply-To:` from `details.replyTos`, right after To and Cc, and fill the reply-to slot of the IMAP ENVELOPE (RFC 3501 §7.4.2), which was hard-wired to From. Both read one iterator, `reply_to_addresses`, that trims addresses and drops blank entries. The `Name <addr>` rendering moves into `format_name_and_address`, which `format_address` now delegates to, so To, Cc and Reply-To share one rendering by construction. No `replyTos` means no header and a From fallback in the envelope.

## Known limits

A body already rendered on disk keeps its current rendering until it is fetched again, so the header appears on new mail immediately and on existing mail after a re-fetch. `SEARCH HEADER REPLY-TO` matches mails whose body is in the warm cache; the envelope falls back to From for a cold body or a body reloaded from disk (addressed in #27). Addresses are emitted verbatim like From/To/Cc (addressed in #26).

## Verification

319 tests, `cargo fmt --check` clean, clippy unchanged from `main`. Live: two Kraken mails re-fetched carry `Reply-To: noreply@marketing.kraken.com` in the header, the envelope and `SEARCH HEADER Reply-To`; mails without a `replyTos` stay without the header. Thunderbird replies to the Reply-To address. IMAP integration suite 10/10.