### PR TITLE
Derive ENVELOPE and SEARCH addresses from the rendered message

### DIFF
--- a/crates/bridge/src/body_cache.rs
+++ b/crates/bridge/src/body_cache.rs
@@ -12,9 +12,9 @@
 //! footprint. Now memory is bounded no matter how many bodies a client pulls.
 //!
 //! `MailDetails` is in-memory only (it is not persisted): after an eviction or
-//! a restart a body re-read from disk has `details: None`. Consumers fall back
-//! to metadata (e.g. ENVELOPE uses `firstRecipient`), which is the same
-//! behavior mails outside the prefetch window always had.
+//! a restart a body re-read from disk has `details: None`. Consumers that need
+//! the addresses (ENVELOPE, SEARCH) then parse them back from the rendered
+//! message, so what they answer follows the on-disk rendering.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex, RwLock};

--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -575,7 +575,7 @@ impl ImapSession {
         let size = rfc.len() as u64;
 
         let details = body.and_then(|b| b.details.as_ref());
-        let addresses = address_headers(details, rfc);
+        let addresses = address_headers(&cached.mail, body);
 
         let sent_ms = details
             .map(|d| d.sentDate.as_millis())
@@ -886,29 +886,35 @@ impl ImapSession {
     }
 }
 
-/// Join a recipient list into a single comparable string for SEARCH.
 /// To / Cc / Bcc / Reply-To of a message as the client should see them.
-/// Exact from `details` while they are in memory; otherwise parsed back from
-/// the rendered message, which is all the disk cache holds after a restart
-/// (the placeholder of an unloaded message included). Bcc is never rendered,
-/// so it is only known while `details` are warm.
-fn address_headers(details: Option<&MailDetails>, rfc: &str) -> AddressHeaders {
+/// Exact from the details while they are in memory; parsed back from the
+/// rendered message for a body reloaded from disk, which is all the disk
+/// keeps after a restart; the envelope `firstRecipient` for a body never
+/// loaded, as its placeholder renders. Bcc is never rendered, so it is only
+/// known while the details are warm.
+fn address_headers(mail: &Mail, body: Option<&crate::body_cache::BodyEntry>) -> AddressHeaders {
     let pairs = |addrs: &[MailAddress]| {
         addrs
             .iter()
             .map(|a| (a.name.clone(), a.address.clone()))
             .collect()
     };
-    match details {
-        Some(d) => AddressHeaders {
-            to: pairs(&d.recipients.toRecipients),
-            cc: pairs(&d.recipients.ccRecipients),
-            bcc: pairs(&d.recipients.bccRecipients),
-            reply_to: reply_to_addresses(d)
-                .map(|(name, address)| (name.to_string(), address.to_string()))
-                .collect(),
+    match body {
+        Some(entry) => match &entry.details {
+            Some(d) => AddressHeaders {
+                to: pairs(&d.recipients.toRecipients),
+                cc: pairs(&d.recipients.ccRecipients),
+                bcc: pairs(&d.recipients.bccRecipients),
+                reply_to: reply_to_addresses(d)
+                    .map(|(name, address)| (name.to_string(), address.to_string()))
+                    .collect(),
+            },
+            None => parse_address_headers(&entry.rfc2822),
         },
-        None => parse_address_headers(rfc),
+        None => AddressHeaders {
+            to: pairs(mail.firstRecipient.as_slice()),
+            ..AddressHeaders::default()
+        },
     }
 }
 
@@ -978,11 +984,8 @@ fn build_fetch_response(
     }
 
     if items_upper.contains("ENVELOPE") {
-        if let Some(rfc) = rfc {
-            let details = body.and_then(|b| b.details.as_ref());
-            let addresses = address_headers(details, rfc);
-            parts.push(format!("ENVELOPE {}", build_envelope(cached, &addresses)));
-        }
+        let addresses = address_headers(&cached.mail, body);
+        parts.push(format!("ENVELOPE {}", build_envelope(cached, &addresses)));
     }
 
     if items_upper.contains("BODYSTRUCTURE") {
@@ -1084,22 +1087,23 @@ fn filter_header_fields(rfc: &str, fields: &[String], negate: bool) -> String {
     out
 }
 
-/// RFC 3501 §7.4.2 envelope. From and sender are the mail's sender; the
-/// address lists come from [`address_headers`]. Bcc, in-reply-to stay NIL.
+/// RFC 3501 §7.4.2 envelope. From and sender are the mail's sender, the
+/// reply-to slot falls back to it when the header is absent; the other
+/// address lists come from [`address_headers`]. Bcc and in-reply-to stay NIL.
 fn build_envelope(cached: &CachedMail, addresses: &AddressHeaders) -> String {
     let mail = &cached.mail;
     let date = format_internal_date(mail.receivedDate.as_millis());
     let subject = imap_string(&mail.subject);
 
-    let from = format!("({})", format_envelope_addr(&mail.sender));
-    let to = envelope_address_list(&addresses.to);
-    let cc = envelope_address_list(&addresses.cc);
-    // The reply-to slot falls back to From only when the header is absent.
+    let sender = [(mail.sender.name.clone(), mail.sender.address.clone())];
+    let from = envelope_address_list(&sender);
     let reply_to = if addresses.reply_to.is_empty() {
         from.clone()
     } else {
         envelope_address_list(&addresses.reply_to)
     };
+    let to = envelope_address_list(&addresses.to);
+    let cc = envelope_address_list(&addresses.cc);
 
     let msg_id = mail
         ._id
@@ -1139,10 +1143,6 @@ fn imap_string(s: &str) -> String {
     } else {
         format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
     }
-}
-
-fn format_envelope_addr(addr: &tutasdk::entities::generated::tutanota::MailAddress) -> String {
-    format_envelope_mailbox(&addr.name, &addr.address)
 }
 
 /// One ENVELOPE address structure: `(name NIL mailbox host)`.
@@ -1470,45 +1470,54 @@ mod tests {
         details
     }
 
+    /// A body fetched during this run: rendered message plus its details.
+    fn warm(mail: &Mail, details: MailDetails) -> crate::body_cache::BodyEntry {
+        crate::body_cache::BodyEntry {
+            rfc2822: crate::mail::mail_to_rfc2822(mail, Some(&details), &[]),
+            details: Some(details),
+        }
+    }
+
+    /// A body reloaded from disk: the rendered message without its details.
+    fn disk_reloaded(mail: &Mail, details: &MailDetails) -> crate::body_cache::BodyEntry {
+        crate::body_cache::BodyEntry {
+            details: None,
+            rfc2822: crate::mail::mail_to_rfc2822(mail, Some(details), &[]),
+        }
+    }
+
+    fn expected_full() -> AddressHeaders {
+        AddressHeaders {
+            to: vec![mailbox("Recip", "recip@test.com")],
+            cc: vec![mailbox("Zoë", "zoe@test.com")],
+            bcc: vec![],
+            reply_to: vec![mailbox("Support", "help@replies.example.com")],
+        }
+    }
+
     #[test]
     fn address_headers_come_from_details_while_they_are_warm() {
-        let details = full_details();
+        let mail = make_mail("m1", "Receipt", false);
+        let mut entry = warm(&mail, full_details());
         // A rendered message that disagrees must lose to the details.
-        let rfc = "To: other@x.com\r\nReply-To: other@x.com\r\n\r\nbody";
-        assert_eq!(
-            address_headers(Some(&details), rfc),
-            AddressHeaders {
-                to: vec![mailbox("Recip", "recip@test.com")],
-                cc: vec![mailbox("Zoë", "zoe@test.com")],
-                bcc: vec![],
-                reply_to: vec![mailbox("Support", "help@replies.example.com")],
-            }
-        );
+        entry.rfc2822 = "To: other@x.com\r\nReply-To: other@x.com\r\n\r\nbody".to_string();
+        assert_eq!(address_headers(&mail, Some(&entry)), expected_full());
     }
 
     #[test]
-    fn address_headers_are_parsed_back_from_the_rendered_message() {
-        // After a restart the disk cache only holds the rendered message: the
+    fn address_headers_are_parsed_back_from_a_body_reloaded_from_disk() {
+        // After a restart the disk only holds the rendered message: the
         // addresses must round-trip through it, display names decoded.
-        let details = full_details();
-        let rfc =
-            crate::mail::mail_to_rfc2822(&make_mail("m1", "Receipt", false), Some(&details), &[]);
-        assert_eq!(
-            address_headers(None, &rfc),
-            AddressHeaders {
-                to: vec![mailbox("Recip", "recip@test.com")],
-                cc: vec![mailbox("Zoë", "zoe@test.com")],
-                bcc: vec![],
-                reply_to: vec![mailbox("Support", "help@replies.example.com")],
-            }
-        );
+        let mail = make_mail("m1", "Receipt", false);
+        let entry = disk_reloaded(&mail, &full_details());
+        assert_eq!(address_headers(&mail, Some(&entry)), expected_full());
     }
 
     #[test]
-    fn address_headers_of_an_unloaded_message_are_its_placeholder_to() {
-        let rfc = crate::mail::mail_to_rfc2822(&make_mail("m1", "Receipt", false), None, &[]);
+    fn address_headers_of_an_unloaded_body_are_the_first_recipient() {
+        let mail = make_mail("m1", "Receipt", false);
         assert_eq!(
-            address_headers(None, &rfc),
+            address_headers(&mail, None),
             AddressHeaders {
                 to: vec![mailbox("Recip", "recip@test.com")],
                 ..AddressHeaders::default()
@@ -1518,8 +1527,7 @@ mod tests {
 
     #[test]
     fn build_envelope_lists_reply_to_and_cc() {
-        let addresses = address_headers(Some(&full_details()), "");
-        let env = build_envelope(&make_test_mail(1, "Receipt", false), &addresses);
+        let env = build_envelope(&make_test_mail(1, "Receipt", false), &expected_full());
         let from = "((\"Sender\" NIL \"sender\" \"tuta.com\"))";
         let reply_to = "((\"Support\" NIL \"help\" \"replies.example.com\"))";
         let to = "((\"Recip\" NIL \"recip\" \"test.com\"))";
@@ -1536,7 +1544,10 @@ mod tests {
     fn build_envelope_without_reply_to_or_cc_falls_back_to_from_and_nil() {
         // RFC 3501 §7.4.2: the reply-to slot repeats From when the header is
         // absent; an empty list is a bare NIL, not an empty parenthesised list.
-        let addresses = address_headers(Some(&make_details("<p>b</p>")), "");
+        let addresses = AddressHeaders {
+            to: vec![mailbox("Recip", "recip@test.com")],
+            ..AddressHeaders::default()
+        };
         let env = build_envelope(&make_test_mail(1, "Receipt", false), &addresses);
         let from = "((\"Sender\" NIL \"sender\" \"tuta.com\"))";
         let to = "((\"Recip\" NIL \"recip\" \"test.com\"))";
@@ -1728,60 +1739,34 @@ mod tests {
     // --- format_envelope_addr ---
 
     #[test]
-    fn test_format_envelope_addr_with_name() {
-        let addr = MailAddress {
-            _id: None,
-            name: "John Doe".to_string(),
-            address: "john@example.com".to_string(),
-            contact: None,
-            _errors: Default::default(),
-        };
+    fn envelope_mailbox_with_name() {
         assert_eq!(
-            format_envelope_addr(&addr),
+            format_envelope_mailbox("John Doe", "john@example.com"),
             "(\"John Doe\" NIL \"john\" \"example.com\")"
         );
     }
 
     #[test]
-    fn test_format_envelope_addr_no_name() {
-        let addr = MailAddress {
-            _id: None,
-            name: "".to_string(),
-            address: "john@example.com".to_string(),
-            contact: None,
-            _errors: Default::default(),
-        };
+    fn envelope_mailbox_without_name() {
         assert_eq!(
-            format_envelope_addr(&addr),
+            format_envelope_mailbox("", "john@example.com"),
             "(NIL NIL \"john\" \"example.com\")"
         );
     }
 
     #[test]
-    fn test_format_envelope_addr_no_domain() {
-        let addr = MailAddress {
-            _id: None,
-            name: "".to_string(),
-            address: "localonly".to_string(),
-            contact: None,
-            _errors: Default::default(),
-        };
-        assert_eq!(format_envelope_addr(&addr), "(NIL NIL \"localonly\" \"\")");
+    fn envelope_mailbox_without_domain() {
+        assert_eq!(
+            format_envelope_mailbox("", "localonly"),
+            "(NIL NIL \"localonly\" \"\")"
+        );
     }
 
     #[test]
-    fn test_format_envelope_addr_quotes_in_name() {
-        let addr = MailAddress {
-            _id: None,
-            name: "John \"JD\" Doe".to_string(),
-            address: "john@example.com".to_string(),
-            contact: None,
-            _errors: Default::default(),
-        };
-        let result = format_envelope_addr(&addr);
+    fn envelope_mailbox_escapes_quotes_in_name() {
         // Inner quotes are backslash-escaped inside the IMAP quoted string.
         assert_eq!(
-            result,
+            format_envelope_mailbox("John \"JD\" Doe", "john@example.com"),
             "(\"John \\\"JD\\\" Doe\" NIL \"john\" \"example.com\")"
         );
     }
@@ -2972,14 +2957,6 @@ mod tests {
             expunge_idx_3 < expunge_idx_2,
             "EXPUNGE 3 must come before EXPUNGE 2, got {resp:?}",
         );
-    }
-
-    /// A body reloaded from disk: the rendered message without its details.
-    fn disk_reloaded(mail: &Mail, details: &MailDetails) -> crate::body_cache::BodyEntry {
-        crate::body_cache::BodyEntry {
-            details: None,
-            rfc2822: crate::mail::mail_to_rfc2822(mail, Some(details), &[]),
-        }
     }
 
     #[tokio::test]

--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -4,8 +4,10 @@ use tutasdk::entities::generated::tutanota::{Mail, MailAddress, MailDetails, Tut
 
 use crate::imap::search::{self, MsgView};
 use crate::mail::mail_to_rfc2822;
+use crate::mail::parser::{parse_address_headers, AddressHeaders};
 use crate::mail::rfc2822::{
-    extract_headers, format_address, format_internal_date, reply_to_addresses,
+    extract_headers, format_address, format_internal_date, format_name_and_address,
+    reply_to_addresses,
 };
 use crate::store::LocalStore;
 use crate::sync::MailStore;
@@ -572,26 +574,8 @@ impl ImapSession {
         let headers = extract_headers(rfc);
         let size = rfc.len() as u64;
 
-        // To/Cc/Bcc come from details when the body entry is warm; otherwise
-        // only the envelope `firstRecipient` (rendered as To) is available.
         let details = body.and_then(|b| b.details.as_ref());
-        let (to, cc, bcc) = match details {
-            Some(d) => (
-                join_addrs(&d.recipients.toRecipients),
-                join_addrs(&d.recipients.ccRecipients),
-                join_addrs(&d.recipients.bccRecipients),
-            ),
-            None => (
-                cached
-                    .mail
-                    .firstRecipient
-                    .as_ref()
-                    .map(format_address)
-                    .unwrap_or_default(),
-                String::new(),
-                String::new(),
-            ),
-        };
+        let addresses = address_headers(details, rfc);
 
         let sent_ms = details
             .map(|d| d.sentDate.as_millis())
@@ -610,9 +594,9 @@ impl ImapSession {
             element_id,
             subject: &cached.mail.subject,
             from: format_address(&cached.mail.sender),
-            to,
-            cc,
-            bcc,
+            to: join_mailboxes(&addresses.to),
+            cc: join_mailboxes(&addresses.cc),
+            bcc: join_mailboxes(&addresses.bcc),
             headers,
             date_ms: cached.mail.receivedDate.as_millis(),
             sent_ms,
@@ -903,10 +887,36 @@ impl ImapSession {
 }
 
 /// Join a recipient list into a single comparable string for SEARCH.
-fn join_addrs(addrs: &[MailAddress]) -> String {
-    addrs
+/// To / Cc / Bcc / Reply-To of a message as the client should see them.
+/// Exact from `details` while they are in memory; otherwise parsed back from
+/// the rendered message, which is all the disk cache holds after a restart
+/// (the placeholder of an unloaded message included). Bcc is never rendered,
+/// so it is only known while `details` are warm.
+fn address_headers(details: Option<&MailDetails>, rfc: &str) -> AddressHeaders {
+    let pairs = |addrs: &[MailAddress]| {
+        addrs
+            .iter()
+            .map(|a| (a.name.clone(), a.address.clone()))
+            .collect()
+    };
+    match details {
+        Some(d) => AddressHeaders {
+            to: pairs(&d.recipients.toRecipients),
+            cc: pairs(&d.recipients.ccRecipients),
+            bcc: pairs(&d.recipients.bccRecipients),
+            reply_to: reply_to_addresses(d)
+                .map(|(name, address)| (name.to_string(), address.to_string()))
+                .collect(),
+        },
+        None => parse_address_headers(rfc),
+    }
+}
+
+/// `Name <addr>, ...` for SEARCH substring matching.
+fn join_mailboxes(mailboxes: &[(String, String)]) -> String {
+    mailboxes
         .iter()
-        .map(format_address)
+        .map(|(name, address)| format_name_and_address(name, address))
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -941,7 +951,6 @@ fn build_fetch_response(
         None
     };
     let rfc: Option<&str> = body.map(|b| b.rfc2822.as_str()).or(placeholder.as_deref());
-    let details: Option<&MailDetails> = body.and_then(|b| b.details.as_ref());
 
     if uid_mode || items_upper.contains("UID") {
         parts.push(format!("UID {}", cached.uid));
@@ -969,7 +978,11 @@ fn build_fetch_response(
     }
 
     if items_upper.contains("ENVELOPE") {
-        parts.push(format!("ENVELOPE {}", build_envelope(cached, details)));
+        if let Some(rfc) = rfc {
+            let details = body.and_then(|b| b.details.as_ref());
+            let addresses = address_headers(details, rfc);
+            parts.push(format!("ENVELOPE {}", build_envelope(cached, &addresses)));
+        }
     }
 
     if items_upper.contains("BODYSTRUCTURE") {
@@ -1071,26 +1084,22 @@ fn filter_header_fields(rfc: &str, fields: &[String], negate: bool) -> String {
     out
 }
 
-/// `details` (when the body entry is warm in cache) provides the full To list;
-/// otherwise the envelope falls back to the metadata `firstRecipient`, as
-/// unloaded messages always have.
-fn build_envelope(cached: &CachedMail, details: Option<&MailDetails>) -> String {
+/// RFC 3501 §7.4.2 envelope. From and sender are the mail's sender; the
+/// address lists come from [`address_headers`]. Bcc, in-reply-to stay NIL.
+fn build_envelope(cached: &CachedMail, addresses: &AddressHeaders) -> String {
     let mail = &cached.mail;
     let date = format_internal_date(mail.receivedDate.as_millis());
     let subject = imap_string(&mail.subject);
 
-    let from = format_envelope_addr(&mail.sender);
-    let to = details
-        .map(|d| {
-            d.recipients
-                .toRecipients
-                .iter()
-                .map(format_envelope_addr)
-                .collect::<Vec<_>>()
-                .join(" ")
-        })
-        .or_else(|| mail.firstRecipient.as_ref().map(format_envelope_addr))
-        .unwrap_or_else(|| "NIL".to_string());
+    let from = format!("({})", format_envelope_addr(&mail.sender));
+    let to = envelope_address_list(&addresses.to);
+    let cc = envelope_address_list(&addresses.cc);
+    // The reply-to slot falls back to From only when the header is absent.
+    let reply_to = if addresses.reply_to.is_empty() {
+        from.clone()
+    } else {
+        envelope_address_list(&addresses.reply_to)
+    };
 
     let msg_id = mail
         ._id
@@ -1099,20 +1108,20 @@ fn build_envelope(cached: &CachedMail, details: Option<&MailDetails>) -> String 
         .unwrap_or_default();
     let msg_id = imap_string(&msg_id);
 
-    // RFC 3501 §7.4.2: the reply-to slot carries the message's Reply-To, and
-    // falls back to From only when the header is absent. Same addresses as
-    // the `Reply-To:` line rendered in the RFC 2822 message.
-    let reply_to = details
-        .map(|d| {
-            reply_to_addresses(d)
-                .map(|(name, address)| format_envelope_mailbox(name, address))
-                .collect::<Vec<_>>()
-                .join(" ")
-        })
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| from.clone());
+    format!("(\"{date}\" {subject} {from} {from} {reply_to} {to} {cc} NIL NIL {msg_id})")
+}
 
-    format!("(\"{date}\" {subject} ({from}) ({from}) ({reply_to}) ({to}) NIL NIL NIL {msg_id})")
+/// An ENVELOPE address list: `((addr) (addr) ...)`, or `NIL` when empty.
+fn envelope_address_list(mailboxes: &[(String, String)]) -> String {
+    if mailboxes.is_empty() {
+        return "NIL".to_string();
+    }
+    let inner = mailboxes
+        .iter()
+        .map(|(name, address)| format_envelope_mailbox(name, address))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("({inner})")
 }
 
 /// Encode a string as an IMAP nstring. Safe 7-bit text becomes a quoted string;
@@ -1415,7 +1424,7 @@ mod tests {
         // string, producing a malformed FETCH response that broke the client's
         // parse of the message list (an empty mailbox in Thunderbird).
         let subj = "La\nselection Courtois - Le bien du mois";
-        let env = build_envelope(&make_test_mail(1, subj, false), None);
+        let env = build_envelope(&make_test_mail(1, subj, false), &AddressHeaders::default());
         assert!(
             env.contains(&format!("{{{}}}\r\n{}", subj.len(), subj)),
             "subject must be a literal, got: {env}"
@@ -1426,11 +1435,24 @@ mod tests {
         );
     }
 
-    #[test]
-    fn build_envelope_reply_to_slot_carries_the_header() {
+    // --- address_headers / build_envelope ---
+
+    fn mailbox(name: &str, address: &str) -> (String, String) {
+        (name.to_string(), address.to_string())
+    }
+
+    /// Details with a To, a Cc and a Reply-To, as a received mail carries them.
+    fn full_details() -> MailDetails {
         use tutasdk::entities::generated::tutanota::EncryptedMailAddress;
 
         let mut details = make_details("<p>b</p>");
+        details.recipients.ccRecipients = vec![MailAddress {
+            _id: None,
+            name: "Zoë".to_string(),
+            address: "zoe@test.com".to_string(),
+            contact: None,
+            _errors: Default::default(),
+        }];
         details.replyTos = vec![
             EncryptedMailAddress {
                 _id: None,
@@ -1445,25 +1467,83 @@ mod tests {
                 _errors: Default::default(),
             },
         ];
-        let env = build_envelope(&make_test_mail(1, "Receipt", false), Some(&details));
-        let from = "((\"Sender\" NIL \"sender\" \"tuta.com\"))";
-        let reply_to = "((\"Support\" NIL \"help\" \"replies.example.com\"))";
-        assert!(
-            env.contains(&format!("{from} {from} {reply_to} ((")),
-            "from, sender, then reply-to: {env}"
+        details
+    }
+
+    #[test]
+    fn address_headers_come_from_details_while_they_are_warm() {
+        let details = full_details();
+        // A rendered message that disagrees must lose to the details.
+        let rfc = "To: other@x.com\r\nReply-To: other@x.com\r\n\r\nbody";
+        assert_eq!(
+            address_headers(Some(&details), rfc),
+            AddressHeaders {
+                to: vec![mailbox("Recip", "recip@test.com")],
+                cc: vec![mailbox("Zoë", "zoe@test.com")],
+                bcc: vec![],
+                reply_to: vec![mailbox("Support", "help@replies.example.com")],
+            }
         );
     }
 
     #[test]
-    fn build_envelope_reply_to_slot_falls_back_to_from() {
-        // RFC 3501 §7.4.2: without a Reply-To header the slot repeats From,
-        // whether details are missing or carry no reply-to at all.
+    fn address_headers_are_parsed_back_from_the_rendered_message() {
+        // After a restart the disk cache only holds the rendered message: the
+        // addresses must round-trip through it, display names decoded.
+        let details = full_details();
+        let rfc =
+            crate::mail::mail_to_rfc2822(&make_mail("m1", "Receipt", false), Some(&details), &[]);
+        assert_eq!(
+            address_headers(None, &rfc),
+            AddressHeaders {
+                to: vec![mailbox("Recip", "recip@test.com")],
+                cc: vec![mailbox("Zoë", "zoe@test.com")],
+                bcc: vec![],
+                reply_to: vec![mailbox("Support", "help@replies.example.com")],
+            }
+        );
+    }
+
+    #[test]
+    fn address_headers_of_an_unloaded_message_are_its_placeholder_to() {
+        let rfc = crate::mail::mail_to_rfc2822(&make_mail("m1", "Receipt", false), None, &[]);
+        assert_eq!(
+            address_headers(None, &rfc),
+            AddressHeaders {
+                to: vec![mailbox("Recip", "recip@test.com")],
+                ..AddressHeaders::default()
+            }
+        );
+    }
+
+    #[test]
+    fn build_envelope_lists_reply_to_and_cc() {
+        let addresses = address_headers(Some(&full_details()), "");
+        let env = build_envelope(&make_test_mail(1, "Receipt", false), &addresses);
         let from = "((\"Sender\" NIL \"sender\" \"tuta.com\"))";
-        let cold = build_envelope(&make_test_mail(1, "Receipt", false), None);
-        assert!(cold.contains(&format!("{from} {from} {from} ")), "{cold}");
-        let details = make_details("<p>b</p>");
-        let warm = build_envelope(&make_test_mail(1, "Receipt", false), Some(&details));
-        assert!(warm.contains(&format!("{from} {from} {from} ")), "{warm}");
+        let reply_to = "((\"Support\" NIL \"help\" \"replies.example.com\"))";
+        let to = "((\"Recip\" NIL \"recip\" \"test.com\"))";
+        let cc = "(({4}\r\nZoë NIL \"zoe\" \"test.com\"))";
+        assert!(
+            env.ends_with(&format!(
+                "{from} {from} {reply_to} {to} {cc} NIL NIL \"<mail_list.mail_elem@tutabridge.local>\")"
+            )),
+            "{env}"
+        );
+    }
+
+    #[test]
+    fn build_envelope_without_reply_to_or_cc_falls_back_to_from_and_nil() {
+        // RFC 3501 §7.4.2: the reply-to slot repeats From when the header is
+        // absent; an empty list is a bare NIL, not an empty parenthesised list.
+        let addresses = address_headers(Some(&make_details("<p>b</p>")), "");
+        let env = build_envelope(&make_test_mail(1, "Receipt", false), &addresses);
+        let from = "((\"Sender\" NIL \"sender\" \"tuta.com\"))";
+        let to = "((\"Recip\" NIL \"recip\" \"test.com\"))";
+        assert!(
+            env.contains(&format!("{from} {from} {from} {to} NIL NIL NIL ")),
+            "{env}"
+        );
     }
 
     // --- parse_command ---
@@ -2892,5 +2972,50 @@ mod tests {
             expunge_idx_3 < expunge_idx_2,
             "EXPUNGE 3 must come before EXPUNGE 2, got {resp:?}",
         );
+    }
+
+    /// A body reloaded from disk: the rendered message without its details.
+    fn disk_reloaded(mail: &Mail, details: &MailDetails) -> crate::body_cache::BodyEntry {
+        crate::body_cache::BodyEntry {
+            details: None,
+            rfc2822: crate::mail::mail_to_rfc2822(mail, Some(details), &[]),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_envelope_and_search_survive_a_body_reloaded_from_disk() {
+        let m1 = make_mail("m1", "Receipt", false);
+        let m2 = make_mail("m2", "Newsletter", false);
+        let backend = Arc::new(MockBackend::with_mails(vec![m1.clone(), m2.clone()]));
+        let (store, mut session) = make_session(backend).await;
+        store
+            .bodies()
+            .insert("m1", disk_reloaded(&m1, &full_details()));
+        store
+            .bodies()
+            .insert("m2", disk_reloaded(&m2, &make_details("<p>b</p>")));
+        session.handle_command("A001 LOGIN user pass").await;
+        session.handle_command("A002 SELECT INBOX").await;
+
+        let resp = session.handle_command("A003 FETCH 1 (ENVELOPE)").await;
+        assert!(
+            resp[0].contains("((\"Support\" NIL \"help\" \"replies.example.com\"))"),
+            "reply-to slot: {}",
+            resp[0]
+        );
+        assert!(
+            resp[0].contains("Zoë NIL \"zoe\" \"test.com\""),
+            "cc slot: {}",
+            resp[0]
+        );
+
+        let resp = session
+            .handle_command(r#"A004 SEARCH CC "zoe@test.com""#)
+            .await;
+        assert_eq!(resp[0], "* SEARCH 1\r\n");
+        let resp = session
+            .handle_command(r#"A005 SEARCH TO "recip@test.com""#)
+            .await;
+        assert_eq!(resp[0], "* SEARCH 1 2\r\n");
     }
 }

--- a/crates/bridge/src/mail/parser.rs
+++ b/crates/bridge/src/mail/parser.rs
@@ -55,20 +55,12 @@ pub fn parse_rfc2822(raw: &str) -> ParsedMessage {
     let from_raw = get_header(&headers, "from").unwrap_or_default();
     let (from_name, from_address) = parse_address_single(&from_raw);
 
-    let to = get_header(&headers, "to")
-        .map(|v| parse_address_list(&v))
-        .unwrap_or_default();
-    let cc = get_header(&headers, "cc")
-        .map(|v| parse_address_list(&v))
-        .unwrap_or_default();
-    let bcc = get_header(&headers, "bcc")
-        .map(|v| parse_address_list(&v))
-        .unwrap_or_default();
-    // A list, not a single address: RFC 5322 §3.6.2 makes Reply-To an
-    // address-list.
-    let reply_to = get_header(&headers, "reply-to")
-        .map(|v| parse_address_list(&v))
-        .unwrap_or_default();
+    let AddressHeaders {
+        to,
+        cc,
+        bcc,
+        reply_to,
+    } = address_headers_of(&headers);
 
     let subject = get_header(&headers, "subject")
         .map(|s| decode_header_value(&s))
@@ -116,6 +108,38 @@ pub fn parse_rfc2822(raw: &str) -> ParsedMessage {
         message_id,
         in_reply_to,
         attachments,
+    }
+}
+
+/// The address-list headers of a message, as `(name, address)` pairs with
+/// display names decoded. A header that is absent yields an empty list.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct AddressHeaders {
+    pub to: Vec<(String, String)>,
+    pub cc: Vec<(String, String)>,
+    pub bcc: Vec<(String, String)>,
+    /// RFC 5322 §3.6.2 makes Reply-To an address-list, not a single address.
+    pub reply_to: Vec<(String, String)>,
+}
+
+/// The address-list headers of a rendered message. Reads the header section
+/// only, so it is cheap on a message with a large body.
+pub(crate) fn parse_address_headers(raw: &str) -> AddressHeaders {
+    let header_section = raw.split_once("\r\n\r\n").map(|(h, _)| h).unwrap_or(raw);
+    address_headers_of(&parse_headers(header_section))
+}
+
+fn address_headers_of(headers: &[(String, String)]) -> AddressHeaders {
+    let list = |name: &str| {
+        get_header(headers, name)
+            .map(|v| parse_address_list(&v))
+            .unwrap_or_default()
+    };
+    AddressHeaders {
+        to: list("to"),
+        cc: list("cc"),
+        bcc: list("bcc"),
+        reply_to: list("reply-to"),
     }
 }
 
@@ -946,5 +970,36 @@ mod tests {
         let input = "caf=C3=A9";
         let result = decode_quoted_printable(input);
         assert_eq!(result, "caf\u{e9}");
+    }
+
+    #[test]
+    fn address_headers_come_from_the_header_section_only() {
+        // Folded To, encoded Cc name, Reply-To list; the body's "To:" line and
+        // the missing Bcc must not leak in.
+        let raw = "From: a@b.com\r\nTo: Bob <bob@x.com>,\r\n charlie@x.com\r\nCc: =?UTF-8?B?Wm/Dqw==?= <zoe@x.com>\r\nReply-To: one@x.com, Two <two@x.com>\r\n\r\nTo: not-a-header@x.com";
+        let parsed = parse_address_headers(raw);
+        assert_eq!(
+            parsed,
+            AddressHeaders {
+                to: vec![
+                    ("Bob".to_string(), "bob@x.com".to_string()),
+                    (String::new(), "charlie@x.com".to_string()),
+                ],
+                cc: vec![("Zoë".to_string(), "zoe@x.com".to_string())],
+                bcc: vec![],
+                reply_to: vec![
+                    (String::new(), "one@x.com".to_string()),
+                    ("Two".to_string(), "two@x.com".to_string()),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn address_headers_of_a_message_without_any_are_empty() {
+        assert_eq!(
+            parse_address_headers("Subject: hi\r\n\r\nbody"),
+            AddressHeaders::default()
+        );
     }
 }

--- a/crates/bridge/src/mail/parser.rs
+++ b/crates/bridge/src/mail/parser.rs
@@ -223,16 +223,36 @@ pub(super) fn get_header(headers: &[(String, String)], name: &str) -> Option<Str
         .map(|(_, v)| v.clone())
 }
 
+/// One mailbox: `Name <addr>` or a bare `addr`. The angle-addr is the last
+/// `<`…`>` pair, since a quoted display name may itself hold `<` or `>`
+/// (`"a > b" <x@y>` used to slice backwards and panic).
 fn parse_address_single(raw: &str) -> (String, String) {
     let raw = raw.trim();
-    if let Some(lt) = raw.find('<') {
-        if let Some(gt) = raw.find('>') {
-            let addr = raw[lt + 1..gt].trim().to_string();
-            let name = decode_header_value(raw[..lt].trim().trim_matches('"'));
+    if let Some(lt) = raw.rfind('<') {
+        if let Some(gt) = raw[lt..].find('>') {
+            let addr = raw[lt + 1..lt + gt].trim().to_string();
+            let name = decode_header_value(&unquote(raw[..lt].trim()));
             return (name, addr);
         }
     }
     (String::new(), raw.to_string())
+}
+
+/// Strip the quotes of an RFC 5322 quoted-string and undo its `\` escapes;
+/// anything else is returned as is.
+fn unquote(phrase: &str) -> String {
+    let Some(inner) = phrase.strip_prefix('"').and_then(|p| p.strip_suffix('"')) else {
+        return phrase.to_string();
+    };
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => out.extend(chars.next()),
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 fn parse_address_list(raw: &str) -> Vec<(String, String)> {
@@ -1001,5 +1021,31 @@ mod tests {
             parse_address_headers("Subject: hi\r\n\r\nbody"),
             AddressHeaders::default()
         );
+    }
+
+    #[test]
+    fn angle_brackets_inside_a_quoted_name_do_not_break_the_mailbox() {
+        // A `>` before the `<` used to slice backwards and panic the parser.
+        let raw = "From: \"a > b\" <x@y.com>\r\nTo: \"c <d>\" <e@f.com>, g@h.com\r\n\r\n";
+        let msg = parse_rfc2822(raw);
+        assert_eq!(
+            (msg.from_name.as_str(), msg.from_address.as_str()),
+            ("a > b", "x@y.com")
+        );
+        assert_eq!(
+            msg.to,
+            vec![
+                ("c <d>".to_string(), "e@f.com".to_string()),
+                (String::new(), "g@h.com".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn quoted_name_escapes_are_undone() {
+        let raw = "From: \"Say \\\"hi\\\" \\\\ bye.\" <a@b.c>\r\n\r\n";
+        let msg = parse_rfc2822(raw);
+        assert_eq!(msg.from_name, "Say \"hi\" \\ bye.");
+        assert_eq!(msg.from_address, "a@b.c");
     }
 }

--- a/crates/bridge/src/mail/parser.rs
+++ b/crates/bridge/src/mail/parser.rs
@@ -125,8 +125,7 @@ pub(crate) struct AddressHeaders {
 /// The address-list headers of a rendered message. Reads the header section
 /// only, so it is cheap on a message with a large body.
 pub(crate) fn parse_address_headers(raw: &str) -> AddressHeaders {
-    let header_section = raw.split_once("\r\n\r\n").map(|(h, _)| h).unwrap_or(raw);
-    address_headers_of(&parse_headers(header_section))
+    address_headers_of(&parse_headers(header_section(raw)))
 }
 
 fn address_headers_of(headers: &[(String, String)]) -> AddressHeaders {
@@ -178,13 +177,20 @@ fn last_msg_id(raw: &str) -> Option<String> {
 }
 
 pub(super) fn split_headers_body(raw: &str) -> (String, String) {
-    if let Some(pos) = raw.find("\r\n\r\n") {
-        (raw[..pos].to_string(), raw[pos + 4..].to_string())
-    } else if let Some(pos) = raw.find("\n\n") {
-        (raw[..pos].to_string(), raw[pos + 2..].to_string())
-    } else {
-        (raw.to_string(), String::new())
-    }
+    let headers = header_section(raw);
+    let body = raw[headers.len()..]
+        .strip_prefix("\r\n\r\n")
+        .or_else(|| raw[headers.len()..].strip_prefix("\n\n"))
+        .unwrap_or("");
+    (headers.to_string(), body.to_string())
+}
+
+/// The header section of a message: everything before the first blank line,
+/// CRLF or bare LF. The whole message when there is none.
+fn header_section(raw: &str) -> &str {
+    raw.find("\r\n\r\n")
+        .or_else(|| raw.find("\n\n"))
+        .map_or(raw, |pos| &raw[..pos])
 }
 
 pub(super) fn parse_headers(header_section: &str) -> Vec<(String, String)> {
@@ -238,11 +244,12 @@ fn parse_address_single(raw: &str) -> (String, String) {
     (String::new(), raw.to_string())
 }
 
-/// Strip the quotes of an RFC 5322 quoted-string and undo its `\` escapes;
-/// anything else is returned as is.
+/// Strip the quotes of an RFC 5322 quoted-string and undo its `\\` escapes.
+/// A phrase that is not one whole quoted-string only loses stray quotes at
+/// its ends, as sloppy senders write `"John <j@x>` and mean `John`.
 fn unquote(phrase: &str) -> String {
     let Some(inner) = phrase.strip_prefix('"').and_then(|p| p.strip_suffix('"')) else {
-        return phrase.to_string();
+        return phrase.trim_matches('"').to_string();
     };
     let mut out = String::with_capacity(inner.len());
     let mut chars = inner.chars();
@@ -261,7 +268,8 @@ fn parse_address_list(raw: &str) -> Vec<(String, String)> {
     let mut in_quotes = false;
     let mut current = String::new();
 
-    for ch in raw.chars() {
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
         match ch {
             // A quoted display name may contain commas and angle brackets that
             // are NOT list separators, e.g. `"Doe, John" <j@x.com>`. Track the
@@ -270,6 +278,12 @@ fn parse_address_list(raw: &str) -> Vec<(String, String)> {
             '"' => {
                 in_quotes = !in_quotes;
                 current.push(ch);
+            }
+            // An escaped character inside the quoted-string (`\\"`, `\\\\`) is
+            // not a delimiter: keep the pair and leave the quote state alone.
+            '\\' if in_quotes => {
+                current.push(ch);
+                current.extend(chars.next());
             }
             '<' if !in_quotes => {
                 depth += 1;
@@ -1047,5 +1061,35 @@ mod tests {
         let msg = parse_rfc2822(raw);
         assert_eq!(msg.from_name, "Say \"hi\" \\ bye.");
         assert_eq!(msg.from_address, "a@b.c");
+    }
+
+    #[test]
+    fn escaped_quotes_inside_a_quoted_name_do_not_split_the_list() {
+        let raw = "To: \"5\\\" screen, big\" <a@b.c>, x@y.z\r\n\r\n";
+        assert_eq!(
+            parse_rfc2822(raw).to,
+            vec![
+                ("5\" screen, big".to_string(), "a@b.c".to_string()),
+                (String::new(), "x@y.z".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn stray_quotes_around_a_name_are_still_trimmed() {
+        let msg = parse_rfc2822("From: \"John <j@x.com>\r\n\r\n");
+        assert_eq!(
+            (msg.from_name.as_str(), msg.from_address.as_str()),
+            ("John", "j@x.com")
+        );
+    }
+
+    #[test]
+    fn address_headers_accept_a_bare_lf_message() {
+        // Same separator rules as parse_rfc2822: the body's "To:" is not a header.
+        assert_eq!(
+            parse_address_headers("To: a@b.c\n\nTo: not-a-header@x.y").to,
+            vec![(String::new(), "a@b.c".to_string())]
+        );
     }
 }

--- a/crates/bridge/src/mail/rfc2822.rs
+++ b/crates/bridge/src/mail/rfc2822.rs
@@ -281,7 +281,7 @@ pub(crate) fn format_address(addr: &MailAddress) -> String {
 /// the characters that delimit a mailbox (`<>`, `,`, `;`, quotes, parentheses,
 /// whitespace) would let a Reply-To we did not write smuggle in a second
 /// recipient for the reply to go to.
-fn format_name_and_address(name: &str, address: &str) -> String {
+pub(crate) fn format_name_and_address(name: &str, address: &str) -> String {
     let address: String = address
         .chars()
         .filter(|c| !c.is_whitespace() && !matches!(c, '<' | '>' | ',' | ';' | '"' | '(' | ')'))


### PR DESCRIPTION
Stacked on #25.

The ENVELOPE address slots and the SEARCH TO/CC/BCC fields read `MailDetails`, which only exist in memory for bodies fetched during the current run. A body reloaded from the disk cache after a restart has no details: its envelope fell back to the metadata `firstRecipient`, Cc was always NIL, the reply-to slot fell back to From even though the served message carries the `Reply-To:` line, and SEARCH CC never matched it.

## Change

`address_headers` picks among three sources: the details while they are in memory (exact), the rendered message for a body reloaded from disk (which is all the disk keeps), and the envelope `firstRecipient` for a body never loaded. ENVELOPE and the SEARCH view both go through it, so a mail answers the same way before and after a restart. The envelope's Cc slot is now filled, an empty list is a bare NIL rather than `(NIL)`, and From goes through the same address-list rendering as every other slot.

The parser gains `parse_address_headers`, one pass over the header section only (16 µs on a 5 MB message), reused by `parse_rfc2822` for its own address fields. Fuzzing the renderer against the parser turned up two pre-existing parser defects, both reachable from an SMTP submission and now from received mail: a display name holding `>` before the `<` sliced backwards and panicked, and `\"` escapes inside a quoted name flipped the quote state and split the list at the next comma. The angle-addr is now the last `<`…`>` pair, escapes are honoured, and quoted-strings are unquoted properly.

## Known limit

Bodies rendered by a previous release and still on disk are parsed as they were written: a "Last, First" recipient rendered unquoted back then reads as two mailboxes on this path, as any client already showed it from the message itself. #26 fixes the rendering for everything fetched from now on; a re-render of the existing cache would be a separate change.

## Verification

330 tests: parser reads a folded To, an encoded Cc name and a Reply-To list from the header section only, honours escaped quotes, trims stray quotes, accepts bare-LF messages; `address_headers` prefers warm details, round-trips a body reloaded from disk (names decoded), and reads `firstRecipient` for an unloaded body; envelope checked slot by slot; a session test reloads two bodies without details and checks FETCH ENVELOPE, SEARCH CC and SEARCH TO. Fuzzed 2000 mails with random To/Cc/Reply-To lists: the disk path yields the same addresses as the details path every time, and Python's `email` parser counts the same mailboxes on all 4640 rendered header lines. Live: after a bridge restart, a Kraken mail reloaded from disk answers ENVELOPE with `noreply@marketing.kraken.com` in the reply-to slot and matches `SEARCH HEADER Reply-To` and `SEARCH TO`.