### PR TITLE
Clear the two warnings this cycle introduced

### DIFF
--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -1,6 +1,6 @@
 use log::{debug, info};
 use std::sync::Arc;
-use tutasdk::entities::generated::tutanota::{Mail, MailAddress, MailDetails, TutanotaFile};
+use tutasdk::entities::generated::tutanota::{Mail, MailAddress, TutanotaFile};
 
 use crate::imap::search::{self, MsgView};
 use crate::mail::mail_to_rfc2822;
@@ -1308,7 +1308,7 @@ mod tests {
     use super::*;
     use base64::Engine;
     use tutasdk::date::DateTime;
-    use tutasdk::entities::generated::tutanota::MailAddress;
+    use tutasdk::entities::generated::tutanota::{MailAddress, MailDetails};
     use tutasdk::GeneratedId;
     use tutasdk::IdTupleGenerated;
 

--- a/crates/bridge/src/tuta.rs
+++ b/crates/bridge/src/tuta.rs
@@ -597,9 +597,9 @@ impl TutaSession {
                 // is a real failure and must not be swallowed -- falling
                 // back on a transport error would turn "the network is
                 // down" into a silently mis-addressed mail.
-                Err(ApiCallError::ServerResponseError { source })
-                    if matches!(source, tutasdk::rest_error::HttpError::NotFoundError) =>
-                {
+                Err(ApiCallError::ServerResponseError {
+                    source: tutasdk::rest_error::HttpError::NotFoundError,
+                }) => {
                     log::warn!(
                         "sending as {} instead of {}: not an enabled alias on this account",
                         self.email,


### PR DESCRIPTION
Release hygiene before cutting rc.10: `cargo clippy --workspace --all-targets` grew from 25 warnings at v0.1.0-rc.9 to 27 on `main`. Both additions are cosmetic, and both are ours.

- `MailDetails` stopped being used in the session's production code when ENVELOPE and the search view moved to `address_headers` (#27), but the import stayed at the top of the file. Only the tests still name the type, so it moves to the test module beside the `MailAddress` they already import.
- The `NotFoundError` arm of `resolve_sender` (#22) matched the error struct and then re-tested its `source` in a guard; the variant goes in the pattern instead.

No behavior change. Clippy is back to the rc.9 warning count, `cargo fmt --check` is clean on the three crates, and the suite passes 336 tests.