### PR TITLE
Take a personal address out of the 2FA example, ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /ui/node_modules
 /ui/dist
+.DS_Store

--- a/crates/bridge/examples/test_2fa.rs
+++ b/crates/bridge/examples/test_2fa.rs
@@ -21,7 +21,7 @@ use tutasdk::Sdk;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let email = std::env::var("TUTA_EMAIL").unwrap_or_else(|_| "mck1@tuta.io".to_string());
+    let email = std::env::var("TUTA_EMAIL").expect("set TUTA_EMAIL to the account to log in as");
     let api_url =
         std::env::var("TUTA_API_URL").unwrap_or_else(|_| "https://app.tuta.com".to_string());
     let password = match std::env::var("TUTA_PASSWORD") {


### PR DESCRIPTION
Two hygiene items found while checking the tree before cutting rc.10.

The `test_2fa` example defaulted `TUTA_EMAIL` to a real Tuta account: running it without the variable set tried to log in as somebody else, and the address sat in a tracked file of a public repo. The variable is now required, which is what the example's own usage line already documents (`TUTA_EMAIL=you@tuta.io ... cargo run --example test_2fa`).

`.DS_Store` joins `.gitignore`. Finder drops one in every directory it opens, and two of them have been sitting in `git status` waiting to be committed by accident.

No production code touched. Clippy stays at 25 warnings, `cargo fmt --check` clean, 336 tests pass, the example still builds.