### PR TITLE
imap: don't log a client's TLS close_notify-less disconnect as ERROR

### DIFF
--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -86,6 +86,22 @@ async fn handle_connection(
         .await?;
     writer.flush().await?;
 
+    run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch).await
+}
+
+/// The command loop shared by every IMAP connection, kept generic over the
+/// stream so it can run against a `tokio::io::duplex` in tests without a real
+/// TLS handshake — `handle_connection` supplies the concrete `TlsStream`.
+async fn run_connection_loop<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    session: &mut ImapSession,
+    store_watch: &mut watch::Receiver<u64>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWriteExt + Unpin,
+{
     let mut line = String::new();
     loop {
         if session.is_idle() {
@@ -146,7 +162,7 @@ async fn handle_connection(
         // read, so it is handled here at the socket level.
         if !session.is_awaiting_auth() {
             if let Some(req) = session::parse_append(trimmed) {
-                handle_append(&mut reader, &mut writer, &session, req).await?;
+                handle_append(reader, writer, session, req).await?;
                 continue;
             }
         }
@@ -319,6 +335,58 @@ mod tests {
     fn other_io_errors_are_not_treated_as_close_notify() {
         let e = std::io::Error::new(ErrorKind::ConnectionReset, "connection reset by peer");
         assert!(!is_close_notify_eof(&e));
+    }
+
+    /// Replays a fixed script of reads: each entry is either a chunk of bytes
+    /// or an error to return, one per `poll_read` call. Lets a test drive the
+    /// connection loop through a scenario a real socket can produce (like a
+    /// close_notify-less disconnect) without a TLS handshake.
+    struct ScriptedReader {
+        script: std::collections::VecDeque<std::io::Result<Vec<u8>>>,
+    }
+
+    impl tokio::io::AsyncRead for ScriptedReader {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            match self.script.pop_front() {
+                Some(Ok(chunk)) => {
+                    buf.put_slice(&chunk);
+                    std::task::Poll::Ready(Ok(()))
+                }
+                Some(Err(e)) => std::task::Poll::Ready(Err(e)),
+                None => std::task::Poll::Ready(Ok(())), // EOF: no more scripted reads
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn connection_loop_ends_quietly_when_client_vanishes_after_login() {
+        // Mirrors the scenario that used to log a false-alarm ERROR: a client
+        // logs in and then just disappears (no LOGOUT, no TLS close_notify) —
+        // e.g. a one-shot CLI tool that runs a single command and exits.
+        let mut script = std::collections::VecDeque::new();
+        script.push_back(Ok(b"a1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
+        script.push_back(Err(std::io::Error::new(
+            ErrorKind::UnexpectedEof,
+            "peer closed connection without sending TLS close_notify",
+        )));
+        let reader = ScriptedReader { script };
+        let mut reader = BufReader::new(reader);
+        let mut writer = tokio::io::sink();
+        let store = MailStore::new();
+        let (_watch_tx, mut store_watch) = watch::channel(0u64);
+        let mut session = ImapSession::new(store, Arc::new(NoopBackend), None, None);
+
+        let result = run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch)
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "a close_notify-less disconnect must end the session quietly, not as an error: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -380,8 +380,8 @@ mod tests {
         let (_watch_tx, mut store_watch) = watch::channel(0u64);
         let mut session = ImapSession::new(store, Arc::new(NoopBackend), None, None);
 
-        let result = run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch)
-            .await;
+        let result =
+            run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch).await;
 
         assert!(
             result.is_ok(),

--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -3,6 +3,7 @@ mod session;
 mod utf7;
 
 use log::{debug, error, info};
+use std::io::ErrorKind;
 use std::sync::Arc;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
@@ -57,6 +58,17 @@ pub async fn serve(
     Ok(())
 }
 
+/// True for the io::Error rustls reports when a peer closes the TCP
+/// connection without sending a TLS close_notify alert first. Under TLS 1.3's
+/// AEAD framing this can't hide a truncated response the way it could
+/// pre-1.3, and short-lived clients that open a connection, run one command
+/// and exit (as most non-interactive IMAP CLI tools do) routinely skip the
+/// clean shutdown. Treating it as an ordinary EOF keeps that common,
+/// harmless case out of the error log.
+fn is_close_notify_eof(e: &std::io::Error) -> bool {
+    e.kind() == ErrorKind::UnexpectedEof
+}
+
 async fn handle_connection(
     stream: tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
     store: Arc<MailStore>,
@@ -80,7 +92,14 @@ async fn handle_connection(
             line.clear();
             tokio::select! {
                 result = reader.read_line(&mut line) => {
-                    let n = result?;
+                    let n = match result {
+                        Ok(n) => n,
+                        Err(e) if is_close_notify_eof(&e) => {
+                            debug!("IMAP client disconnected without a TLS close_notify while idle: {e}");
+                            break;
+                        }
+                        Err(e) => return Err(e.into()),
+                    };
                     if n == 0 {
                         break;
                     }
@@ -108,7 +127,14 @@ async fn handle_connection(
         }
 
         line.clear();
-        let n = reader.read_line(&mut line).await?;
+        let n = match reader.read_line(&mut line).await {
+            Ok(n) => n,
+            Err(e) if is_close_notify_eof(&e) => {
+                debug!("IMAP client disconnected without a TLS close_notify: {e}");
+                break;
+            }
+            Err(e) => return Err(e.into()),
+        };
         if n == 0 {
             break;
         }
@@ -278,6 +304,21 @@ mod tests {
         };
         store.set_folder_list(vec![sent]).await;
         ImapSession::new(store, Arc::new(NoopBackend), None, None)
+    }
+
+    #[test]
+    fn close_notify_eof_is_recognized() {
+        let e = std::io::Error::new(
+            ErrorKind::UnexpectedEof,
+            "peer closed connection without sending TLS close_notify",
+        );
+        assert!(is_close_notify_eof(&e));
+    }
+
+    #[test]
+    fn other_io_errors_are_not_treated_as_close_notify() {
+        let e = std::io::Error::new(ErrorKind::ConnectionReset, "connection reset by peer");
+        assert!(!is_close_notify_eof(&e));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Short-lived IMAP clients (a one-shot CLI tool that runs a single command and exits, rather than sending LOGOUT + a clean TLS shutdown) routinely close the connection without a close_notify alert. rustls surfaces that as an io::Error, which was propagated to the top-level handler and logged at `error!`, so nearly every non-interactive client produced a false-alarm ERROR line.
- Per rustls's own docs, TLS 1.3's AEAD framing means a missing close_notify can't hide a truncated response the way it could pre-1.3, so this classifies `io::ErrorKind::UnexpectedEof` at the two main-loop read sites and ends the session quietly (debug log) instead of propagating as an error.
- `handle_append`'s literal read is untouched — an EOF mid-APPEND is a genuine interruption, not a benign disconnect.

## Test plan
- [x] `cargo test -p tutabridge-core imap::` — 114 passed (includes 2 new tests for the error classifier)
- [x] `cargo test -p tutabridge-core` (full suite) — 338 passed
- [x] `cargo clippy -p tutabridge-core --lib -- -D warnings` — no new findings in the changed file (11 pre-existing findings elsewhere, untouched)
- [x] Found live: reproduced against a real himalaya CLI session hitting this bridge, confirmed the ERROR line correlates exactly with the CLI process exiting after AUTHENTICATE PLAIN