### PR TITLE
imap: log session lifecycle at INFO, tagged with a per-connection id

### DIFF
--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -331,6 +331,20 @@ mod tests {
         }
     }
 
+    #[test]
+    fn session_counter_yields_unique_increasing_ids() {
+        let a = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let b = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
+        assert_ne!(
+            a, b,
+            "concurrent connections must not share a log-correlation id"
+        );
+        assert!(
+            b > a,
+            "ids must keep increasing so the newest connection is easy to spot in logs"
+        );
+    }
+
     async fn session_with_sent() -> ImapSession {
         let store = MailStore::new();
         let sent = FolderInfo {

--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -4,6 +4,7 @@ mod utf7;
 
 use log::{debug, error, info};
 use std::io::ErrorKind;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
@@ -14,6 +15,12 @@ use crate::store::LocalStore;
 use crate::sync::MailStore;
 use crate::tuta::MailBackend;
 use session::ImapSession;
+
+/// Numbers IMAP connections in acceptance order so log lines from concurrent
+/// or overlapping sessions (auth, commands, the eventual disconnect) can be
+/// told apart. Purely a log-correlation id — never persisted, never sent to
+/// a client.
+static SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 pub async fn serve(
     port: u16,
@@ -30,25 +37,35 @@ pub async fn serve(
         listener,
         "IMAP",
         crate::net::MAX_CONNECTIONS,
-        move |stream, _addr| {
+        move |stream, addr| {
             let store = store.clone();
             let backend = backend.clone();
             let local_store = local_store.clone();
             let tls = tls.clone();
             let pw_hash = password_hash.clone();
             async move {
+                let session_id = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
                 match tokio::time::timeout(crate::net::HANDSHAKE_TIMEOUT, tls.accept(stream)).await
                 {
                     Ok(Ok(tls_stream)) => {
-                        if let Err(e) =
-                            handle_connection(tls_stream, store, backend, local_store, pw_hash)
-                                .await
+                        info!("IMAP session {session_id}: opened ({addr})");
+                        if let Err(e) = handle_connection(
+                            tls_stream,
+                            session_id,
+                            store,
+                            backend,
+                            local_store,
+                            pw_hash,
+                        )
+                        .await
                         {
-                            error!("IMAP connection error: {}", e);
+                            error!("IMAP session {session_id}: connection error: {e}");
                         }
                     }
-                    Ok(Err(e)) => error!("IMAP TLS handshake failed: {}", e),
-                    Err(_) => debug!("IMAP TLS handshake timed out"),
+                    Ok(Err(e)) => {
+                        error!("IMAP session {session_id}: TLS handshake failed ({addr}): {e}")
+                    }
+                    Err(_) => debug!("IMAP session {session_id}: TLS handshake timed out ({addr})"),
                 }
             }
         },
@@ -71,6 +88,7 @@ fn is_close_notify_eof(e: &std::io::Error) -> bool {
 
 async fn handle_connection(
     stream: tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
+    session_id: u64,
     store: Arc<MailStore>,
     backend: Arc<dyn MailBackend>,
     local_store: Arc<LocalStore>,
@@ -79,7 +97,8 @@ async fn handle_connection(
     let (reader, mut writer) = tokio::io::split(stream);
     let mut reader = BufReader::new(reader);
     let mut store_watch: watch::Receiver<u64> = store.subscribe();
-    let mut session = ImapSession::new(store, backend, password_hash, Some(local_store));
+    let mut session = ImapSession::new(store, backend, password_hash, Some(local_store))
+        .with_session_id(session_id);
 
     writer
         .write_all(b"* OK TutaBridge IMAP4rev1 ready\r\n")
@@ -102,6 +121,7 @@ where
     R: AsyncBufRead + Unpin,
     W: AsyncWriteExt + Unpin,
 {
+    let session_id = session.session_id();
     let mut line = String::new();
     loop {
         if session.is_idle() {
@@ -111,12 +131,13 @@ where
                     let n = match result {
                         Ok(n) => n,
                         Err(e) if is_close_notify_eof(&e) => {
-                            debug!("IMAP client disconnected without a TLS close_notify while idle: {e}");
+                            debug!("IMAP session {session_id}: ended, client disconnected without a TLS close_notify while idle: {e}");
                             break;
                         }
                         Err(e) => return Err(e.into()),
                     };
                     if n == 0 {
+                        info!("IMAP session {session_id}: ended, client disconnected cleanly while idle");
                         break;
                     }
                     let trimmed = line.trim_end();
@@ -146,12 +167,13 @@ where
         let n = match reader.read_line(&mut line).await {
             Ok(n) => n,
             Err(e) if is_close_notify_eof(&e) => {
-                debug!("IMAP client disconnected without a TLS close_notify: {e}");
+                debug!("IMAP session {session_id}: ended, client disconnected without a TLS close_notify: {e}");
                 break;
             }
             Err(e) => return Err(e.into()),
         };
         if n == 0 {
+            info!("IMAP session {session_id}: ended, client disconnected cleanly");
             break;
         }
 
@@ -179,6 +201,7 @@ where
         writer.flush().await?;
 
         if session.is_logout() {
+            info!("IMAP session {session_id}: ended, client sent LOGOUT");
             break;
         }
     }

--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -2793,6 +2793,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn with_session_id_tags_the_session_for_log_correlation() {
+        let backend = Arc::new(MockBackend::new());
+        let (_store, session) = make_session(backend).await;
+        assert_eq!(
+            session.session_id, 0,
+            "a session built without with_session_id() is untagged (matches unit-test construction)"
+        );
+
+        let backend = Arc::new(MockBackend::new());
+        let (_store, session) = make_session(backend).await;
+        let session = session.with_session_id(42);
+        assert_eq!(session.session_id, 42);
+    }
+
+    #[tokio::test]
     async fn test_logout() {
         let backend = Arc::new(MockBackend::new());
         let (_store, mut session) = make_session(backend).await;

--- a/crates/bridge/src/imap/session.rs
+++ b/crates/bridge/src/imap/session.rs
@@ -46,6 +46,10 @@ pub struct ImapSession {
     idle_tag: Option<String>,
     auth_tag: Option<String>,
     password_hash: Option<String>,
+    /// Log-correlation id for the connection this session belongs to (see
+    /// `imap::SESSION_COUNTER`). `0` in unit tests, which construct a session
+    /// with no connection behind it.
+    session_id: u64,
 }
 
 impl ImapSession {
@@ -66,7 +70,20 @@ impl ImapSession {
             idle_tag: None,
             auth_tag: None,
             password_hash,
+            session_id: 0,
         }
+    }
+
+    /// Tags this session's log lines with a connection id so they can be
+    /// paired with the open/close lines logged around it in `imap::mod`.
+    pub fn with_session_id(mut self, session_id: u64) -> Self {
+        self.session_id = session_id;
+        self
+    }
+
+    /// The connection id this session's log lines are tagged with.
+    pub fn session_id(&self) -> u64 {
+        self.session_id
     }
 
     pub fn is_logout(&self) -> bool {
@@ -121,7 +138,10 @@ impl ImapSession {
         }
 
         self.state = State::Authenticated;
-        info!("IMAP client authenticated via AUTHENTICATE PLAIN");
+        info!(
+            "IMAP session {}: authenticated via AUTHENTICATE PLAIN",
+            self.session_id
+        );
         vec![format!("{} OK AUTHENTICATE completed\r\n", tag)]
     }
 
@@ -275,7 +295,10 @@ impl ImapSession {
             }
         }
         self.state = State::Authenticated;
-        info!("IMAP client authenticated (bridge session)");
+        info!(
+            "IMAP session {}: authenticated (bridge session)",
+            self.session_id
+        );
         vec![format!("{} OK LOGIN completed\r\n", tag)]
     }
 


### PR DESCRIPTION
Session open ("IMAP client authenticated (bridge session)") was already logged at INFO, but nothing marked the other end of that session at any level: LOGOUT and a clean TLS shutdown (EOF after a real close_notify) were both silent. Operationally that meant you could see how many clients had authenticated but never how or when a session actually ended.

The bridge accepts up to 64 concurrent connections (net.rs's MAX_CONNECTIONS, one tokio task each via accept_loop), and a single mail client alone can hold several open at once -- one per selected folder plus one parked in IDLE -- so their log lines already interleave. Adding open/close visibility without a way to tell which lines belong to which connection would just produce more interleaved noise, not more signal. So this does both together, as one feature:

- Number connections in acceptance order (a simple AtomicU64 counter, allocated once per accepted connection) and thread the id through every log line for that connection's lifetime: TLS handshake failure/timeout, session open, both auth paths (AUTHENTICATE PLAIN and LOGIN) in session.rs, and every termination path.
- Log the three previously-silent termination points at INFO: LOGOUT, clean EOF while idle, and clean EOF in the main loop. This mirrors the existing precedent in src/main.rs of logging every WsState transition at INFO specifically so reconnect storms are visible in production logs without RUST_LOG=debug.

Session id is threaded into ImapSession via a with_session_id() builder rather than a new required constructor argument, since session.rs's own test module has ~9 unrelated ImapSession::new call sites that don't need to know about it.

Deliberately out of scope here: the close_notify-less disconnect, which is still ERROR on this branch -- that's a separate, independent fix (see the fix-imap-eof-noise branch).

## Live verification

Ran against a real bridge instance with 3 overlapping IMAP clients per batch (staggered ~50ms apart, held open long enough to genuinely overlap: 2 clean `LOGOUT`, 1 abrupt close), twice in a row so ids keep incrementing across batches:

```
[2026-08-31T00:45:29Z INFO  tutabridge_core::imap] IMAP session 1: opened (127.0.0.1:36406)
[2026-08-31T00:45:29Z INFO  tutabridge_core::imap::session] IMAP session 1: authenticated (bridge session)
[2026-08-31T00:45:29Z INFO  tutabridge_core::imap] IMAP session 2: opened (127.0.0.1:36416)
[2026-08-31T00:45:29Z INFO  tutabridge_core::imap::session] IMAP session 2: authenticated (bridge session)
[2026-08-31T00:45:29Z INFO  tutabridge_core::imap] IMAP session 3: opened (127.0.0.1:36432)
[2026-08-31T00:45:29Z INFO  tutabridge_core::imap::session] IMAP session 3: authenticated (bridge session)
[2026-08-31T00:45:30Z ERROR tutabridge_core::imap] IMAP session 2: connection error: peer closed connection without sending TLS close_notify: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
[2026-08-31T00:45:31Z INFO  tutabridge_core::imap] IMAP session 1: ended, client sent LOGOUT
[2026-08-31T00:45:31Z INFO  tutabridge_core::imap] IMAP session 3: ended, client sent LOGOUT
[2026-08-31T00:46:06Z INFO  tutabridge_core::imap] IMAP session 4: opened (127.0.0.1:37144)
[2026-08-31T00:46:06Z INFO  tutabridge_core::imap::session] IMAP session 4: authenticated (bridge session)
[2026-08-31T00:46:06Z INFO  tutabridge_core::imap] IMAP session 5: opened (127.0.0.1:37148)
[2026-08-31T00:46:06Z INFO  tutabridge_core::imap::session] IMAP session 5: authenticated (bridge session)
[2026-08-31T00:46:06Z INFO  tutabridge_core::imap] IMAP session 6: opened (127.0.0.1:37154)
[2026-08-31T00:46:06Z INFO  tutabridge_core::imap::session] IMAP session 6: authenticated (bridge session)
[2026-08-31T00:46:07Z ERROR tutabridge_core::imap] IMAP session 5: connection error: peer closed connection without sending TLS close_notify: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
[2026-08-31T00:46:07Z INFO  tutabridge_core::imap] IMAP session 4: ended, client sent LOGOUT
[2026-08-31T00:46:08Z INFO  tutabridge_core::imap] IMAP session 6: ended, client sent LOGOUT
```

Confirms the actual point of the feature: even with three connections' auth/command/close lines interleaved, each session's `opened` → `authenticated` → `ended` triplet is unambiguous by id (1/1/1, 2/2/2, 3/3/3, ...). Session 2 and 5 (the abrupt closes) correctly stay `ERROR` here -- that's `fix-imap-eof-noise`'s job, not this branch's; this branch only adds the id and the two previously-silent clean-close paths.
