### PR TITLE
Keep client credentials out of the command log

### DIFF
--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -69,6 +69,31 @@ fn is_close_notify_eof(e: &std::io::Error) -> bool {
     e.kind() == ErrorKind::UnexpectedEof
 }
 
+/// The client line as it may be logged: a `LOGIN` keeps its tag and verb but
+/// loses its arguments, `AUTHENTICATE` loses any initial response, and the
+/// continuation line that answers an `AUTHENTICATE` challenge is replaced
+/// whole, since it is nothing but the base64 credentials. Every other line is
+/// returned as is. The GUI shows the log on screen, so a mail client logging
+/// in must not put the bridge password there.
+fn redact_credentials(line: &str, awaiting_auth: bool) -> std::borrow::Cow<'_, str> {
+    if awaiting_auth {
+        return "<credentials>".into();
+    }
+    let mut words = line.split_whitespace();
+    let (Some(tag), Some(verb)) = (words.next(), words.next()) else {
+        return line.into();
+    };
+    if verb.eq_ignore_ascii_case("LOGIN") {
+        return format!("{tag} {verb} <credentials>").into();
+    }
+    if verb.eq_ignore_ascii_case("AUTHENTICATE") {
+        if let (Some(mechanism), Some(_initial_response)) = (words.next(), words.next()) {
+            return format!("{tag} {verb} {mechanism} <credentials>").into();
+        }
+    }
+    line.into()
+}
+
 async fn handle_connection(
     stream: tokio_rustls::server::TlsStream<tokio::net::TcpStream>,
     store: Arc<MailStore>,
@@ -156,7 +181,10 @@ where
         }
 
         let trimmed = line.trim_end();
-        debug!("IMAP C: {}", trimmed);
+        debug!(
+            "IMAP C: {}",
+            redact_credentials(trimmed, session.is_awaiting_auth())
+        );
 
         // APPEND carries a message literal the line-based session layer cannot
         // read, so it is handled here at the socket level.
@@ -239,6 +267,51 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn login_arguments_are_redacted() {
+        assert_eq!(
+            redact_credentials(r#"a1 LOGIN "me@tuta.com" "s3cret-pw""#, false),
+            "a1 LOGIN <credentials>"
+        );
+        assert_eq!(
+            redact_credentials("a1 login me@tuta.com s3cret-pw", false),
+            "a1 login <credentials>"
+        );
+    }
+
+    #[test]
+    fn authenticate_challenge_response_is_redacted_whole() {
+        // The bare `AUTHENTICATE PLAIN` carries nothing; the next line is the
+        // base64 of \0user\0password and must not reach the log.
+        assert_eq!(
+            redact_credentials("a1 AUTHENTICATE PLAIN", false),
+            "a1 AUTHENTICATE PLAIN"
+        );
+        assert_eq!(
+            redact_credentials("AG1lQHR1dGEuY29tAHMzY3JldC1wdw==", true),
+            "<credentials>"
+        );
+    }
+
+    #[test]
+    fn authenticate_initial_response_is_redacted() {
+        // SASL-IR (RFC 4959): a client may send the credentials inline.
+        assert_eq!(
+            redact_credentials(
+                "a1 AUTHENTICATE PLAIN AG1lQHR1dGEuY29tAHMzY3JldC1wdw==",
+                false
+            ),
+            "a1 AUTHENTICATE PLAIN <credentials>"
+        );
+    }
+
+    #[test]
+    fn other_commands_are_logged_verbatim() {
+        for line in ["a2 SELECT INBOX", "a3 FETCH 1:* (FLAGS)", "DONE", ""] {
+            assert_eq!(redact_credentials(line, false), line);
+        }
+    }
     use crate::mail::parser::ParsedMessage;
     use crate::tuta::FolderInfo;
     use tokio::io::AsyncReadExt;

--- a/crates/bridge/src/smtp/mod.rs
+++ b/crates/bridge/src/smtp/mod.rs
@@ -121,6 +121,25 @@ enum AuthStep {
     WaitLoginPass,
 }
 
+/// The client line as it may be logged. While an `AUTH` exchange is in
+/// progress every line is a credential (the PLAIN blob, or LOGIN's username
+/// then password), and `AUTH <mechanism> <initial-response>` carries them
+/// inline; those are replaced. Everything else is returned as is.
+fn redact_credentials<'a>(line: &'a str, step: &AuthStep) -> std::borrow::Cow<'a, str> {
+    if !matches!(step, AuthStep::None) {
+        return "<credentials>".into();
+    }
+    let mut words = line.split_whitespace();
+    if let (Some(verb), Some(mechanism), Some(_initial_response)) =
+        (words.next(), words.next(), words.next())
+    {
+        if verb.eq_ignore_ascii_case("AUTH") {
+            return format!("{verb} {mechanism} <credentials>").into();
+        }
+    }
+    line.into()
+}
+
 pub async fn serve(
     port: u16,
     tuta: Arc<dyn MailBackend>,
@@ -193,7 +212,7 @@ where
         }
 
         let trimmed = line.trim_end();
-        debug!("SMTP C: {}", trimmed);
+        debug!("SMTP C: {}", redact_credentials(trimmed, &auth_step));
 
         if !matches!(auth_step, AuthStep::None) {
             let response = match auth_step {
@@ -428,6 +447,45 @@ fn verify_smtp_password(password: &str, expected: &Option<String>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn auth_plain_inline_credentials_are_redacted() {
+        assert_eq!(
+            redact_credentials(
+                "AUTH PLAIN AG1lQHR1dGEuY29tAHMzY3JldC1wdw==",
+                &AuthStep::None
+            ),
+            "AUTH PLAIN <credentials>"
+        );
+        assert_eq!(
+            redact_credentials("AUTH PLAIN", &AuthStep::None),
+            "AUTH PLAIN"
+        );
+    }
+
+    #[test]
+    fn every_line_of_an_auth_exchange_is_redacted() {
+        // PLAIN's blob after `334 `, then LOGIN's username and password lines.
+        for step in [
+            AuthStep::WaitPlainData,
+            AuthStep::WaitLoginUser,
+            AuthStep::WaitLoginPass,
+        ] {
+            assert_eq!(redact_credentials("czNjcmV0LXB3", &step), "<credentials>");
+        }
+    }
+
+    #[test]
+    fn other_commands_are_logged_verbatim() {
+        for line in [
+            "EHLO localhost",
+            "MAIL FROM:<me@tuta.com>",
+            "AUTH LOGIN",
+            "QUIT",
+        ] {
+            assert_eq!(redact_credentials(line, &AuthStep::None), line);
+        }
+    }
 
     #[test]
     fn test_extract_address_angle_brackets() {


### PR DESCRIPTION
Both servers echo every client line at debug. A mail client logging in therefore put the bridge password in the log: in clear for `LOGIN "user" "pass"`, and as trivially decoded base64 for `AUTHENTICATE PLAIN`, `AUTH PLAIN` and `AUTH LOGIN`. The CLI defaults to `info`, so it was only exposed with `RUST_LOG=debug`; the GUI runs `tutabridge_core=debug` by default and writes to the process stderr, which lands in the terminal when launched from one (including `dev.sh`) and, on Linux, commonly in journald when launched from a desktop session. It is in every release so far. #19 covered a different leak, the CLI printing the password at startup.

Correction to the first version of this description: the GUI's in-app log panel is fed by a separate, hand-curated channel (`emit_log`), not by the `log` crate, so these lines were never shown in the app window. The exposure is the process stderr described above.

## Change

Each server gets a `redact_credentials` that the echo goes through. IMAP keeps the tag and verb of a `LOGIN` and drops its arguments, drops any initial response after `AUTHENTICATE <mechanism>` (SASL-IR, which a client may send even though the bridge does not accept it yet), and replaces the whole continuation line while an `AUTHENTICATE` challenge is pending, since that line is nothing but the credentials. SMTP does the same for `AUTH <mechanism> <initial-response>` and for every line of a pending `AUTH` exchange, PLAIN's blob and LOGIN's username and password alike. Anything else is logged verbatim.

What the log shows now:

```
IMAP C: a1 LOGIN <credentials>
IMAP C: a1 AUTHENTICATE PLAIN
IMAP C: <credentials>
SMTP C: AUTH PLAIN <credentials>
SMTP C: AUTH LOGIN
SMTP C: <credentials>
SMTP C: <credentials>
```

## Verification

346 tests (7 new: each credential-bearing form redacted, other commands untouched). Live against the GUI: all four authentication forms still succeed, and the bridge password appears zero times in the resulting log, searched in clear and in both base64 encodings. `cargo fmt --check` clean, clippy unchanged from `main`.