### PR TITLE
Treat a reset like an EOF on both servers, redact the idle echo, test at the logger

### DIFF
--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -3,7 +3,6 @@ mod session;
 mod utf7;
 
 use log::{debug, error, info};
-use std::io::ErrorKind;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -75,17 +74,6 @@ pub async fn serve(
     Ok(())
 }
 
-/// True for the io::Error rustls reports when a peer closes the TCP
-/// connection without sending a TLS close_notify alert first. Under TLS 1.3's
-/// AEAD framing this can't hide a truncated response the way it could
-/// pre-1.3, and short-lived clients that open a connection, run one command
-/// and exit (as most non-interactive IMAP CLI tools do) routinely skip the
-/// clean shutdown. Treating it as an ordinary EOF keeps that common,
-/// harmless case out of the error log.
-fn is_close_notify_eof(e: &std::io::Error) -> bool {
-    e.kind() == ErrorKind::UnexpectedEof
-}
-
 /// The client line as it may be logged: a `LOGIN` keeps its tag and verb but
 /// loses its arguments, `AUTHENTICATE` loses any initial response, and the
 /// continuation line that answers an `AUTHENTICATE` challenge is replaced
@@ -155,8 +143,8 @@ where
                 result = reader.read_line(&mut line) => {
                     let n = match result {
                         Ok(n) => n,
-                        Err(e) if is_close_notify_eof(&e) => {
-                            debug!("IMAP session {session_id}: ended, client disconnected without a TLS close_notify while idle: {e}");
+                        Err(e) if crate::net::is_benign_disconnect(&e) => {
+                            debug!("IMAP session {session_id}: ended, client went away without a clean shutdown while idle: {e}");
                             break;
                         }
                         Err(e) => return Err(e.into()),
@@ -166,7 +154,10 @@ where
                         break;
                     }
                     let trimmed = line.trim_end();
-                    debug!("IMAP C (idle): {}", trimmed);
+                    debug!(
+                        "IMAP C (idle): {}",
+                        redact_credentials(trimmed, session.is_awaiting_auth())
+                    );
                     if trimmed.eq_ignore_ascii_case("DONE") {
                         let responses = session.end_idle();
                         for resp in &responses {
@@ -191,8 +182,8 @@ where
         line.clear();
         let n = match reader.read_line(&mut line).await {
             Ok(n) => n,
-            Err(e) if is_close_notify_eof(&e) => {
-                debug!("IMAP session {session_id}: ended, client disconnected without a TLS close_notify: {e}");
+            Err(e) if crate::net::is_benign_disconnect(&e) => {
+                debug!("IMAP session {session_id}: ended, client went away without a clean shutdown: {e}");
                 break;
             }
             Err(e) => return Err(e.into()),
@@ -432,21 +423,6 @@ mod tests {
         ImapSession::new(store, Arc::new(NoopBackend), None, None)
     }
 
-    #[test]
-    fn close_notify_eof_is_recognized() {
-        let e = std::io::Error::new(
-            ErrorKind::UnexpectedEof,
-            "peer closed connection without sending TLS close_notify",
-        );
-        assert!(is_close_notify_eof(&e));
-    }
-
-    #[test]
-    fn other_io_errors_are_not_treated_as_close_notify() {
-        let e = std::io::Error::new(ErrorKind::ConnectionReset, "connection reset by peer");
-        assert!(!is_close_notify_eof(&e));
-    }
-
     /// Replays a fixed script of reads: each entry is either a chunk of bytes
     /// or an error to return, one per `poll_read` call. Lets a test drive the
     /// connection loop through a scenario a real socket can produce (like a
@@ -480,7 +456,7 @@ mod tests {
         let mut script = std::collections::VecDeque::new();
         script.push_back(Ok(b"a1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
         script.push_back(Err(std::io::Error::new(
-            ErrorKind::UnexpectedEof,
+            std::io::ErrorKind::UnexpectedEof,
             "peer closed connection without sending TLS close_notify",
         )));
         let reader = ScriptedReader { script };
@@ -496,6 +472,98 @@ mod tests {
         assert!(
             result.is_ok(),
             "a close_notify-less disconnect must end the session quietly, not as an error: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn connection_loop_ends_quietly_when_client_resets_after_login() {
+        // The other way a one-shot client goes away: it exits with the
+        // server's reply still unread, so the kernel answers with a reset
+        // rather than a FIN. Same outcome expected: no error.
+        let mut script = std::collections::VecDeque::new();
+        script.push_back(Ok(b"a1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
+        script.push_back(Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "Connection reset by peer (os error 54)",
+        )));
+        let mut reader = BufReader::new(ScriptedReader { script });
+        let mut writer = tokio::io::sink();
+        let (_watch_tx, mut store_watch) = watch::channel(0u64);
+        let mut session = ImapSession::new(MailStore::new(), Arc::new(NoopBackend), None, None);
+
+        let result =
+            run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch).await;
+
+        assert!(
+            result.is_ok(),
+            "a reset must end the session quietly: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_command_log_never_carries_a_login_password() {
+        // Drives the real connection loop and reads the real logger output:
+        // this is what proves the redaction sits at the emission site and
+        // not only in a helper. The marker is unique to this test so the
+        // shared capture can be filtered despite parallel tests.
+        crate::net::log_capture::install();
+        let marker = "PW-a1b2c3-main-loop";
+        let mut script = std::collections::VecDeque::new();
+        script.push_back(Ok(
+            format!("a1 LOGIN \"user\" \"{marker}\"\r\n").into_bytes()
+        ));
+        script.push_back(Ok(b"a2 LOGOUT\r\n".to_vec()));
+        let mut reader = BufReader::new(ScriptedReader { script });
+        let mut writer = tokio::io::sink();
+        let (_watch_tx, mut store_watch) = watch::channel(0u64);
+        let mut session = ImapSession::new(MailStore::new(), Arc::new(NoopBackend), None, None);
+
+        run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch)
+            .await
+            .unwrap();
+
+        assert!(
+            crate::net::log_capture::lines_containing(marker).is_empty(),
+            "the password reached the log"
+        );
+        assert!(
+            !crate::net::log_capture::lines_containing("IMAP C: a1 LOGIN <credentials>").is_empty(),
+            "the LOGIN line should be logged, redacted"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_idle_command_log_never_carries_a_login_password() {
+        // A client is not supposed to send anything but DONE while idling; one
+        // that sends a LOGIN anyway must not have it echoed in clear.
+        crate::net::log_capture::install();
+        let marker = "PW-d4e5f6-idle-loop";
+        let mut script = std::collections::VecDeque::new();
+        script.push_back(Ok(b"a1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
+        script.push_back(Ok(b"a2 SELECT Sent\r\n".to_vec()));
+        script.push_back(Ok(b"a3 IDLE\r\n".to_vec()));
+        script.push_back(Ok(
+            format!("a4 LOGIN \"user\" \"{marker}\"\r\n").into_bytes()
+        ));
+        script.push_back(Ok(b"DONE\r\n".to_vec()));
+        script.push_back(Ok(b"a5 LOGOUT\r\n".to_vec()));
+        let mut reader = BufReader::new(ScriptedReader { script });
+        let mut writer = tokio::io::sink();
+        let (_watch_tx, mut store_watch) = watch::channel(0u64);
+        let mut session = session_with_sent().await;
+
+        run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch)
+            .await
+            .unwrap();
+
+        assert!(
+            crate::net::log_capture::lines_containing(marker).is_empty(),
+            "the password reached the log through the idle echo"
+        );
+        assert!(
+            !crate::net::log_capture::lines_containing("IMAP C (idle): a4 LOGIN <credentials>")
+                .is_empty(),
+            "the idle LOGIN line should be logged, redacted"
         );
     }
 

--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -501,6 +501,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_real_read_error_still_ends_the_connection_as_an_error() {
+        // Only a peer going away is benign. Anything else the stream reports
+        // must keep surfacing, or a broken TLS record would be logged as a
+        // quiet disconnect.
+        let mut script = std::collections::VecDeque::new();
+        script.push_back(Ok(b"a1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
+        script.push_back(Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "received corrupt message",
+        )));
+        let mut reader = BufReader::new(ScriptedReader { script });
+        let mut writer = tokio::io::sink();
+        let (_watch_tx, mut store_watch) = watch::channel(0u64);
+        let mut session = ImapSession::new(MailStore::new(), Arc::new(NoopBackend), None, None);
+
+        let result =
+            run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch).await;
+
+        assert!(
+            result.is_err(),
+            "a corrupt stream must not pass for a disconnect"
+        );
+    }
+
+    #[tokio::test]
+    async fn while_idle_a_disconnect_ends_quietly_and_a_real_error_does_not() {
+        // The IDLE branch has its own read site with the same two outcomes.
+        for (kind, expect_ok) in [
+            (std::io::ErrorKind::UnexpectedEof, true),
+            (std::io::ErrorKind::ConnectionReset, true),
+            (std::io::ErrorKind::InvalidData, false),
+        ] {
+            let mut script = std::collections::VecDeque::new();
+            script.push_back(Ok(b"a1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
+            script.push_back(Ok(b"a2 SELECT Sent\r\n".to_vec()));
+            script.push_back(Ok(b"a3 IDLE\r\n".to_vec()));
+            script.push_back(Err(std::io::Error::new(kind, "while idling")));
+            let mut reader = BufReader::new(ScriptedReader { script });
+            let mut writer = tokio::io::sink();
+            let (_watch_tx, mut store_watch) = watch::channel(0u64);
+            let mut session = session_with_sent().await;
+
+            let result =
+                run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch).await;
+
+            assert!(
+                session.is_idle(),
+                "the script must have reached IDLE for this to test the idle read site"
+            );
+            assert_eq!(result.is_ok(), expect_ok, "{kind:?} while idle: {result:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn an_append_literal_cut_short_is_still_an_error() {
+        // The one place a mid-stream EOF means a truncated message: the client
+        // announced a 10-byte literal and vanished. This must not be filed
+        // under "went away quietly".
+        let mut script = std::collections::VecDeque::new();
+        script.push_back(Ok(b"a1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
+        script.push_back(Ok(b"a2 APPEND Sent {10}\r\n".to_vec()));
+        let mut reader = BufReader::new(ScriptedReader { script });
+        let mut writer = tokio::io::sink();
+        let (_watch_tx, mut store_watch) = watch::channel(0u64);
+        let mut session = session_with_sent().await;
+
+        let result =
+            run_connection_loop(&mut reader, &mut writer, &mut session, &mut store_watch).await;
+
+        assert!(
+            result.is_err(),
+            "a truncated APPEND literal must surface: {result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn the_command_log_never_carries_a_login_password() {
         // Drives the real connection loop and reads the real logger output:
         // this is what proves the redaction sits at the emission site and

--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -504,8 +504,8 @@ mod tests {
     async fn the_command_log_never_carries_a_login_password() {
         // Drives the real connection loop and reads the real logger output:
         // this is what proves the redaction sits at the emission site and
-        // not only in a helper. The marker is unique to this test so the
-        // shared capture can be filtered despite parallel tests.
+        // not only in a helper. The capture is scoped to this test's thread;
+        // the marker is the one string that must never show up in it.
         crate::net::log_capture::install();
         let marker = "PW-a1b2c3-main-loop";
         let mut script = std::collections::VecDeque::new();

--- a/crates/bridge/src/imap/mod.rs
+++ b/crates/bridge/src/imap/mod.rs
@@ -510,9 +510,9 @@ mod tests {
         let marker = "PW-a1b2c3-main-loop";
         let mut script = std::collections::VecDeque::new();
         script.push_back(Ok(
-            format!("a1 LOGIN \"user\" \"{marker}\"\r\n").into_bytes()
+            format!("m1 LOGIN \"user\" \"{marker}\"\r\n").into_bytes()
         ));
-        script.push_back(Ok(b"a2 LOGOUT\r\n".to_vec()));
+        script.push_back(Ok(b"m2 LOGOUT\r\n".to_vec()));
         let mut reader = BufReader::new(ScriptedReader { script });
         let mut writer = tokio::io::sink();
         let (_watch_tx, mut store_watch) = watch::channel(0u64);
@@ -527,9 +527,11 @@ mod tests {
             "the password reached the log"
         );
         assert!(
-            !crate::net::log_capture::lines_containing("IMAP C: a1 LOGIN <credentials>").is_empty(),
+            !crate::net::log_capture::lines_containing("IMAP C: m1 LOGIN <credentials>").is_empty(),
             "the LOGIN line should be logged, redacted"
         );
+        // The script was consumed as written, down to the LOGOUT.
+        assert!(!crate::net::log_capture::lines_containing("IMAP C: m2 LOGOUT").is_empty());
     }
 
     #[tokio::test]
@@ -539,14 +541,14 @@ mod tests {
         crate::net::log_capture::install();
         let marker = "PW-d4e5f6-idle-loop";
         let mut script = std::collections::VecDeque::new();
-        script.push_back(Ok(b"a1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
-        script.push_back(Ok(b"a2 SELECT Sent\r\n".to_vec()));
-        script.push_back(Ok(b"a3 IDLE\r\n".to_vec()));
+        script.push_back(Ok(b"i1 LOGIN \"user\" \"pass\"\r\n".to_vec()));
+        script.push_back(Ok(b"i2 SELECT Sent\r\n".to_vec()));
+        script.push_back(Ok(b"i3 IDLE\r\n".to_vec()));
         script.push_back(Ok(
-            format!("a4 LOGIN \"user\" \"{marker}\"\r\n").into_bytes()
+            format!("i4 LOGIN \"user\" \"{marker}\"\r\n").into_bytes()
         ));
         script.push_back(Ok(b"DONE\r\n".to_vec()));
-        script.push_back(Ok(b"a5 LOGOUT\r\n".to_vec()));
+        script.push_back(Ok(b"i5 LOGOUT\r\n".to_vec()));
         let mut reader = BufReader::new(ScriptedReader { script });
         let mut writer = tokio::io::sink();
         let (_watch_tx, mut store_watch) = watch::channel(0u64);
@@ -561,10 +563,13 @@ mod tests {
             "the password reached the log through the idle echo"
         );
         assert!(
-            !crate::net::log_capture::lines_containing("IMAP C (idle): a4 LOGIN <credentials>")
+            !crate::net::log_capture::lines_containing("IMAP C (idle): i4 LOGIN <credentials>")
                 .is_empty(),
             "the idle LOGIN line should be logged, redacted"
         );
+        // The script was consumed as written: IDLE was entered (the LOGIN
+        // above went through the idle echo), DONE left it, and LOGOUT ran.
+        assert!(!crate::net::log_capture::lines_containing("IMAP C: i5 LOGOUT").is_empty());
     }
 
     #[tokio::test]

--- a/crates/bridge/src/net.rs
+++ b/crates/bridge/src/net.rs
@@ -69,9 +69,7 @@ pub(crate) mod log_capture {
         }
         fn log(&self, record: &log::Record) {
             if record.target().starts_with("tutabridge_core") {
-                RECORDS
-                    .lock()
-                    .unwrap()
+                crate::util::lock_recover(&RECORDS)
                     .push((thread::current().id(), record.args().to_string()));
             }
         }
@@ -91,9 +89,7 @@ pub(crate) mod log_capture {
     /// Every record the calling thread logged that contains `needle`.
     pub(crate) fn lines_containing(needle: &str) -> Vec<String> {
         let me = thread::current().id();
-        RECORDS
-            .lock()
-            .unwrap()
+        crate::util::lock_recover(&RECORDS)
             .iter()
             .filter(|(t, l)| *t == me && l.contains(needle))
             .map(|(_, l)| l.clone())
@@ -145,16 +141,20 @@ pub(crate) async fn accept_loop<F, Fut>(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::AsyncWriteExt;
+
     #[test]
     fn a_peer_that_vanishes_is_a_benign_disconnect() {
         use std::io::{Error, ErrorKind};
         // rustls: TCP EOF with no close_notify.
-        assert!(super::is_benign_disconnect(&Error::new(
+        assert!(is_benign_disconnect(&Error::new(
             ErrorKind::UnexpectedEof,
             "peer closed connection without sending TLS close_notify"
         )));
         // The kernel: peer closed with data still unread.
-        assert!(super::is_benign_disconnect(&Error::new(
+        assert!(is_benign_disconnect(&Error::new(
             ErrorKind::ConnectionReset,
             "Connection reset by peer (os error 54)"
         )));
@@ -163,16 +163,12 @@ mod tests {
     #[test]
     fn a_real_stream_error_is_not() {
         use std::io::{Error, ErrorKind};
-        assert!(!super::is_benign_disconnect(&Error::new(
+        assert!(!is_benign_disconnect(&Error::new(
             ErrorKind::InvalidData,
             "received corrupt message"
         )));
-        assert!(!super::is_benign_disconnect(&Error::from(ErrorKind::Other)));
+        assert!(!is_benign_disconnect(&Error::from(ErrorKind::Other)));
     }
-
-    use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use tokio::io::AsyncWriteExt;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn loop_keeps_accepting_across_connections() {

--- a/crates/bridge/src/net.rs
+++ b/crates/bridge/src/net.rs
@@ -146,6 +146,32 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     #[test]
+    fn captured_records_are_scoped_to_the_thread_that_logged_them() {
+        // The whole point of the capture: what another thread logs is
+        // invisible here, and what this thread logs is not visible there.
+        super::log_capture::install();
+        let here = "CAPTURE-SCOPE-here";
+        let there = "CAPTURE-SCOPE-there";
+        log::debug!("{here}");
+        let seen_there = std::thread::spawn(move || {
+            log::debug!("{there}");
+            (
+                super::log_capture::lines_containing(there).len(),
+                super::log_capture::lines_containing(here).len(),
+            )
+        })
+        .join()
+        .unwrap();
+        assert_eq!(
+            seen_there,
+            (1, 0),
+            "the other thread sees only its own record"
+        );
+        assert_eq!(super::log_capture::lines_containing(here).len(), 1);
+        assert!(super::log_capture::lines_containing(there).is_empty());
+    }
+
+    #[test]
     fn a_peer_that_vanishes_is_a_benign_disconnect() {
         use std::io::{Error, ErrorKind};
         // rustls: TCP EOF with no close_notify.

--- a/crates/bridge/src/net.rs
+++ b/crates/bridge/src/net.rs
@@ -46,14 +46,19 @@ pub(crate) fn is_benign_disconnect(e: &std::io::Error) -> bool {
 
 /// A `log::Log` that keeps every record from this crate so a test can assert
 /// on what a code path logged, which is the only way to prove a log line was
-/// redacted at its emission site rather than in a helper nobody calls. The
-/// logger is process-global and can be installed once, so it is shared by
-/// every test module and filtered by content, since tests run in parallel.
+/// redacted at its emission site rather than in a helper nobody calls.
+///
+/// The logger is process-global and can be installed once, so it is shared by
+/// every test module. Each record remembers the thread that emitted it and a
+/// test only ever reads its own: tests run in parallel, each on its own
+/// thread, on a `current_thread` runtime, so nothing another test logs can
+/// satisfy or spoil an assertion here.
 #[cfg(test)]
 pub(crate) mod log_capture {
     use std::sync::{Mutex, Once};
+    use std::thread::{self, ThreadId};
 
-    static RECORDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    static RECORDS: Mutex<Vec<(ThreadId, String)>> = Mutex::new(Vec::new());
     static INSTALL: Once = Once::new();
 
     struct Capture;
@@ -64,7 +69,10 @@ pub(crate) mod log_capture {
         }
         fn log(&self, record: &log::Record) {
             if record.target().starts_with("tutabridge_core") {
-                RECORDS.lock().unwrap().push(record.args().to_string());
+                RECORDS
+                    .lock()
+                    .unwrap()
+                    .push((thread::current().id(), record.args().to_string()));
             }
         }
         fn flush(&self) {}
@@ -80,14 +88,15 @@ pub(crate) mod log_capture {
         });
     }
 
-    /// Every captured record that contains `needle`.
+    /// Every record the calling thread logged that contains `needle`.
     pub(crate) fn lines_containing(needle: &str) -> Vec<String> {
+        let me = thread::current().id();
         RECORDS
             .lock()
             .unwrap()
             .iter()
-            .filter(|l| l.contains(needle))
-            .cloned()
+            .filter(|(t, l)| *t == me && l.contains(needle))
+            .map(|(_, l)| l.clone())
             .collect()
     }
 }

--- a/crates/bridge/src/net.rs
+++ b/crates/bridge/src/net.rs
@@ -24,6 +24,74 @@ pub(crate) const MAX_CONNECTIONS: usize = 64;
 /// a file descriptor forever.
 pub(crate) const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// True for the read errors a peer produces by going away without a clean
+/// TLS shutdown: a TCP EOF with no close_notify, which rustls reports as
+/// `UnexpectedEof`, or a TCP reset, which the kernel sends when the peer
+/// closes with data still unread (`ConnectionReset`). One-shot mail clients
+/// exit both ways all the time.
+///
+/// rustls's own guidance (its manual, "Unexpected EOF") is that a protocol
+/// whose messages carry their own length framing can treat this like an
+/// ordinary EOF, since nothing is ever delimited by the close of the
+/// connection and so nothing can be truncated unnoticed. IMAP (CRLF lines and
+/// `{n}` literals) and SMTP (CRLF lines and a `.`-terminated DATA) both do.
+/// The one place a mid-stream EOF does mean a truncated message, an IMAP
+/// literal cut short, keeps propagating it as the error it is.
+pub(crate) fn is_benign_disconnect(e: &std::io::Error) -> bool {
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::UnexpectedEof | std::io::ErrorKind::ConnectionReset
+    )
+}
+
+/// A `log::Log` that keeps every record from this crate so a test can assert
+/// on what a code path logged, which is the only way to prove a log line was
+/// redacted at its emission site rather than in a helper nobody calls. The
+/// logger is process-global and can be installed once, so it is shared by
+/// every test module and filtered by content, since tests run in parallel.
+#[cfg(test)]
+pub(crate) mod log_capture {
+    use std::sync::{Mutex, Once};
+
+    static RECORDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    static INSTALL: Once = Once::new();
+
+    struct Capture;
+
+    impl log::Log for Capture {
+        fn enabled(&self, _: &log::Metadata) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record) {
+            if record.target().starts_with("tutabridge_core") {
+                RECORDS.lock().unwrap().push(record.args().to_string());
+            }
+        }
+        fn flush(&self) {}
+    }
+
+    static CAPTURE: Capture = Capture;
+
+    /// Install the capturing logger (idempotent) at debug level.
+    pub(crate) fn install() {
+        INSTALL.call_once(|| {
+            log::set_logger(&CAPTURE).expect("no other logger is installed in tests");
+            log::set_max_level(log::LevelFilter::Debug);
+        });
+    }
+
+    /// Every captured record that contains `needle`.
+    pub(crate) fn lines_containing(needle: &str) -> Vec<String> {
+        RECORDS
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|l| l.contains(needle))
+            .cloned()
+            .collect()
+    }
+}
+
 /// Accept connections forever, handing each to `handle` on its own task.
 ///
 /// Robust by construction:
@@ -68,6 +136,31 @@ pub(crate) async fn accept_loop<F, Fut>(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_peer_that_vanishes_is_a_benign_disconnect() {
+        use std::io::{Error, ErrorKind};
+        // rustls: TCP EOF with no close_notify.
+        assert!(super::is_benign_disconnect(&Error::new(
+            ErrorKind::UnexpectedEof,
+            "peer closed connection without sending TLS close_notify"
+        )));
+        // The kernel: peer closed with data still unread.
+        assert!(super::is_benign_disconnect(&Error::new(
+            ErrorKind::ConnectionReset,
+            "Connection reset by peer (os error 54)"
+        )));
+    }
+
+    #[test]
+    fn a_real_stream_error_is_not() {
+        use std::io::{Error, ErrorKind};
+        assert!(!super::is_benign_disconnect(&Error::new(
+            ErrorKind::InvalidData,
+            "received corrupt message"
+        )));
+        assert!(!super::is_benign_disconnect(&Error::from(ErrorKind::Other)));
+    }
+
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::io::AsyncWriteExt;

--- a/crates/bridge/src/smtp/mod.rs
+++ b/crates/bridge/src/smtp/mod.rs
@@ -958,6 +958,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_real_read_error_still_ends_the_connection_as_an_error() {
+        let mut script = std::collections::VecDeque::new();
+        script.push_back(Ok(b"EHLO localhost\r\n".to_vec()));
+        script.push_back(Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "received corrupt message",
+        )));
+        let result = handle_connection(
+            ScriptedStream { script },
+            Arc::new(CountingBackend::default()) as Arc<dyn MailBackend>,
+            None,
+            SmtpLimits::default(),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "a corrupt stream must not pass for a disconnect"
+        );
+    }
+
+    #[tokio::test]
     async fn the_command_log_never_carries_auth_credentials() {
         // Real handler, real logger output: proves the redaction is wired at
         // the emission site. The capture is scoped to this test's thread; the

--- a/crates/bridge/src/smtp/mod.rs
+++ b/crates/bridge/src/smtp/mod.rs
@@ -202,7 +202,15 @@ where
     let mut authenticated = password_hash.is_none();
 
     loop {
-        match read_line_capped(&mut reader, limits.max_line_bytes, &mut line).await? {
+        let outcome = match read_line_capped(&mut reader, limits.max_line_bytes, &mut line).await {
+            Ok(outcome) => outcome,
+            Err(e) if crate::net::is_benign_disconnect(&e) => {
+                debug!("SMTP client went away without a clean shutdown: {e}");
+                break;
+            }
+            Err(e) => return Err(e.into()),
+        };
+        match outcome {
             LineOutcome::Eof => break,
             LineOutcome::TooLong => {
                 writer.write_all(b"500 5.5.2 line too long\r\n").await?;
@@ -877,5 +885,114 @@ mod tests {
 
         client.write_all(b"QUIT\r\n").await.unwrap();
         let _ = h.await;
+    }
+
+    /// Replays scripted reads (bytes or an error per `poll_read`) and swallows
+    /// writes, so a test can put the connection handler through a disconnect a
+    /// `duplex` cannot produce.
+    struct ScriptedStream {
+        script: std::collections::VecDeque<std::io::Result<Vec<u8>>>,
+    }
+
+    impl tokio::io::AsyncRead for ScriptedStream {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            match self.script.pop_front() {
+                Some(Ok(chunk)) => {
+                    buf.put_slice(&chunk);
+                    std::task::Poll::Ready(Ok(()))
+                }
+                Some(Err(e)) => std::task::Poll::Ready(Err(e)),
+                None => std::task::Poll::Ready(Ok(())),
+            }
+        }
+    }
+
+    impl tokio::io::AsyncWrite for ScriptedStream {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Ready(Ok(buf.len()))
+        }
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn connection_ends_quietly_when_client_vanishes_after_ehlo() {
+        // Both ways a one-shot client goes away, neither may end as an error.
+        for kind in [
+            std::io::ErrorKind::UnexpectedEof,
+            std::io::ErrorKind::ConnectionReset,
+        ] {
+            let mut script = std::collections::VecDeque::new();
+            script.push_back(Ok(b"EHLO localhost\r\n".to_vec()));
+            script.push_back(Err(std::io::Error::new(kind, "peer went away")));
+            let result = handle_connection(
+                ScriptedStream { script },
+                Arc::new(CountingBackend::default()) as Arc<dyn MailBackend>,
+                None,
+                SmtpLimits::default(),
+            )
+            .await;
+            assert!(
+                result.is_ok(),
+                "{kind:?} must end the session quietly: {result:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn the_command_log_never_carries_auth_credentials() {
+        // Real handler, real logger output: proves the redaction is wired at
+        // the emission site. The marker is unique to this test so the shared
+        // capture can be filtered despite parallel tests.
+        crate::net::log_capture::install();
+        let marker = "PW-9f8e7d-smtp";
+        let blob = base64::engine::general_purpose::STANDARD.encode(format!("\0user\0{marker}"));
+        let mut script = std::collections::VecDeque::new();
+        script.push_back(Ok(b"EHLO localhost\r\n".to_vec()));
+        script.push_back(Ok(format!("AUTH PLAIN {blob}\r\n").into_bytes()));
+        script.push_back(Ok(b"AUTH LOGIN\r\n".to_vec()));
+        script.push_back(Ok(format!(
+            "{}\r\n",
+            base64::engine::general_purpose::STANDARD.encode(marker)
+        )
+        .into_bytes()));
+        script.push_back(Ok(b"QUIT\r\n".to_vec()));
+        handle_connection(
+            ScriptedStream { script },
+            Arc::new(CountingBackend::default()) as Arc<dyn MailBackend>,
+            None,
+            SmtpLimits::default(),
+        )
+        .await
+        .unwrap();
+
+        for needle in [marker, blob.as_str()] {
+            assert!(
+                crate::net::log_capture::lines_containing(needle).is_empty(),
+                "credentials reached the log: {needle}"
+            );
+        }
+        assert!(
+            !crate::net::log_capture::lines_containing("SMTP C: AUTH PLAIN <credentials>")
+                .is_empty()
+        );
     }
 }

--- a/crates/bridge/src/smtp/mod.rs
+++ b/crates/bridge/src/smtp/mod.rs
@@ -960,8 +960,8 @@ mod tests {
     #[tokio::test]
     async fn the_command_log_never_carries_auth_credentials() {
         // Real handler, real logger output: proves the redaction is wired at
-        // the emission site. The marker is unique to this test so the shared
-        // capture can be filtered despite parallel tests.
+        // the emission site. The capture is scoped to this test's thread; the
+        // marker is the one string that must never show up in it.
         crate::net::log_capture::install();
         let marker = "PW-9f8e7d-smtp";
         let blob = base64::engine::general_purpose::STANDARD.encode(format!("\0user\0{marker}"));

--- a/crates/bridge/src/smtp/mod.rs
+++ b/crates/bridge/src/smtp/mod.rs
@@ -968,12 +968,13 @@ mod tests {
         let mut script = std::collections::VecDeque::new();
         script.push_back(Ok(b"EHLO localhost\r\n".to_vec()));
         script.push_back(Ok(format!("AUTH PLAIN {blob}\r\n").into_bytes()));
+        // AUTH LOGIN reads two lines after the command: the username, then
+        // the password. The marker goes in the password line only, so the
+        // assertion below pins that step and not the username one.
+        let b64 = |s: &str| base64::engine::general_purpose::STANDARD.encode(s);
         script.push_back(Ok(b"AUTH LOGIN\r\n".to_vec()));
-        script.push_back(Ok(format!(
-            "{}\r\n",
-            base64::engine::general_purpose::STANDARD.encode(marker)
-        )
-        .into_bytes()));
+        script.push_back(Ok(format!("{}\r\n", b64("user")).into_bytes()));
+        script.push_back(Ok(format!("{}\r\n", b64(marker)).into_bytes()));
         script.push_back(Ok(b"QUIT\r\n".to_vec()));
         handle_connection(
             ScriptedStream { script },
@@ -984,7 +985,7 @@ mod tests {
         .await
         .unwrap();
 
-        for needle in [marker, blob.as_str()] {
+        for needle in [marker, blob.as_str(), b64(marker).as_str()] {
             assert!(
                 crate::net::log_capture::lines_containing(needle).is_empty(),
                 "credentials reached the log: {needle}"
@@ -993,6 +994,12 @@ mod tests {
         assert!(
             !crate::net::log_capture::lines_containing("SMTP C: AUTH PLAIN <credentials>")
                 .is_empty()
+        );
+        // The script was consumed as written: QUIT ran as a command, which it
+        // cannot have if a line went missing and it was read as the password.
+        assert!(
+            !crate::net::log_capture::lines_containing("SMTP C: QUIT").is_empty(),
+            "QUIT was swallowed by the AUTH LOGIN exchange"
         );
     }
 }


### PR DESCRIPTION
Three loose ends from #31 and #33, found by probing the running bridge rather than reading it.

## A reset is the other way a client goes away

A client that exits with the server's reply still unread makes the kernel answer with a TCP reset, not a FIN. The bridge then sees `ConnectionReset`, which #31 did not classify, so the ERROR that change set out to remove was still there for one of the two ways a one-shot client disconnects (reproduced deterministically: drain the reply then close gives `UnexpectedEof`, close with the reply unread gives `Connection reset by peer`). The classifier moves to `net::is_benign_disconnect`, covers both, and is grounded in rustls's own guidance rather than a TLS version: a protocol whose messages carry their own length framing, as IMAP and SMTP both do, can treat an unclean close like an ordinary EOF, since nothing can be truncated unnoticed. SMTP had the same ERROR for the same disconnects and goes through it too; a DATA cut short is never forwarded, since `send_mail` only runs on the terminator. An IMAP literal cut short still propagates, as before.

## The idle echo was not redacted

Only `DONE` is valid while idling and anything else is ignored, but a client that sends a `LOGIN` anyway had its password logged in clear through `IMAP C (idle):`. It now goes through the same `redact_credentials` as the main loop.

## The redaction tests were at the wrong level

The tests of #33 exercised the helper, not the call site: removing `redact_credentials` from an echo left the suite green. A test-only capturing logger (`net::log_capture`) lets a test drive the real connection loop and read the real log output. Three tests assert that a `LOGIN` in the main loop, a `LOGIN` while idle and an SMTP `AUTH` exchange never put the password in the log, do log the redacted line, and ran their script to the end (`LOGOUT`, `QUIT`).

Two things were fixed in review. The SMTP script was one line short, so the marker went through the username step and `QUIT` was read as the password (caught by @ninjapanzer); the marker now goes through the password step only. And the capture was process-wide and filtered by content, so a neighbouring test's `a1 LOGIN` or `QUIT` could have satisfied a positive assertion depending on scheduling; each record now carries the emitting thread's id and a test reads only its own, which holds because tests run one per thread on a `current_thread` runtime.

## Verification

358 tests, parallel and serial runs all green; `cargo fmt --check` clean; clippy unchanged from `main`. Twelve mutations each fail the tests meant for them: the three echoes left unredacted, the SMTP password step left unredacted, `UnexpectedEof` or `ConnectionReset` dropped from the classifier, the SMTP read site propagating again, every read error swallowed on either server, the IDLE read site left without its disconnect arm or swallowing everything, an APPEND literal cut short swallowed, and the capture ignoring its thread scope. Thread isolation checked by having the SMTP test assert on a `QUIT` it no longer sends while three other tests do: it fails every run.

Live against the GUI, nine sessions covering every authentication form and IMAP and SMTP each disconnected by FIN and by reset: zero ERROR lines, zero occurrences of the bridge password in clear or base64, the idle `LOGIN` echoed as `<credentials>`, integration suite 10/10. Only test code changed after that pass.
