### PR TITLE
aur: bump tutabridge-bin to v0.1.0-rc.11

### DIFF
--- a/packaging/aur/tutabridge-bin/.SRCINFO
+++ b/packaging/aur/tutabridge-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = tutabridge-bin
 	pkgdesc = Local IMAP/SMTP bridge for Tuta encrypted email (prebuilt headless CLI/daemon)
-	pkgver = 0.1.0rc10
+	pkgver = 0.1.0rc11
 	pkgrel = 1
 	url = https://github.com/spartanz51/tutabridge
 	arch = x86_64
@@ -11,10 +11,10 @@ pkgbase = tutabridge-bin
 	optdepends = kwallet: alternative Secret Service provider
 	provides = tutabridge
 	conflicts = tutabridge
-	source = tutabridge-0.1.0rc10::https://github.com/spartanz51/tutabridge/releases/download/v0.1.0-rc.10/tutabridge-linux-x86_64
-	source = tutabridge.service::https://raw.githubusercontent.com/spartanz51/tutabridge/v0.1.0-rc.10/packaging/systemd/tutabridge.service
-	source = LICENSE::https://raw.githubusercontent.com/spartanz51/tutabridge/v0.1.0-rc.10/LICENSE
-	sha256sums = 41d83fdd063ee1366874422610563b5d45c12779530e2389d1d53490dc1072fe
+	source = tutabridge-0.1.0rc11::https://github.com/spartanz51/tutabridge/releases/download/v0.1.0-rc.11/tutabridge-linux-x86_64
+	source = tutabridge.service::https://raw.githubusercontent.com/spartanz51/tutabridge/v0.1.0-rc.11/packaging/systemd/tutabridge.service
+	source = LICENSE::https://raw.githubusercontent.com/spartanz51/tutabridge/v0.1.0-rc.11/LICENSE
+	sha256sums = 59b9fe66e14e513e39fd181fee59d6b6d6ea786180ffdedc74c4933f5b8dad35
 	sha256sums = 9c398acf860036a8912a3f0686cfd6dc55cb714fc3ddbff68c21755777cd439f
 	sha256sums = 947215ddc328843b76022d5b77e1ca3b1152301778d33e24491e5064e92fc6cf
 

--- a/packaging/aur/tutabridge-bin/PKGBUILD
+++ b/packaging/aur/tutabridge-bin/PKGBUILD
@@ -5,7 +5,7 @@
 # For a build-from-source VCS package, see tutabridge-git.
 
 pkgname=tutabridge-bin
-pkgver=0.1.0rc10
+pkgver=0.1.0rc11
 pkgrel=1
 pkgdesc="Local IMAP/SMTP bridge for Tuta encrypted email (prebuilt headless CLI/daemon)"
 arch=('x86_64')
@@ -16,11 +16,11 @@ optdepends=('gnome-keyring: persist the Tuta session across reboots (Secret Serv
             'kwallet: alternative Secret Service provider')
 provides=('tutabridge')
 conflicts=('tutabridge')
-_tag=v0.1.0-rc.10
+_tag=v0.1.0-rc.11
 source=("tutabridge-$pkgver::$url/releases/download/$_tag/tutabridge-linux-x86_64"
         "tutabridge.service::https://raw.githubusercontent.com/spartanz51/tutabridge/$_tag/packaging/systemd/tutabridge.service"
         "LICENSE::https://raw.githubusercontent.com/spartanz51/tutabridge/$_tag/LICENSE")
-sha256sums=('41d83fdd063ee1366874422610563b5d45c12779530e2389d1d53490dc1072fe'
+sha256sums=('59b9fe66e14e513e39fd181fee59d6b6d6ea786180ffdedc74c4933f5b8dad35'
             '9c398acf860036a8912a3f0686cfd6dc55cb714fc3ddbff68c21755777cd439f'
             '947215ddc328843b76022d5b77e1ca3b1152301778d33e24491e5064e92fc6cf')
 


### PR DESCRIPTION
Follows the v0.1.0-rc.11 release. `pkgver`, `_tag` and the binary's sha256 point at the new tag; the systemd unit and the LICENSE are byte-identical to rc.10, so their two checksums are unchanged.

Validated in an `archlinux` container on x86_64: `makepkg -f` builds and verifies all three checksums, `makepkg --printsrcinfo` is identical to the committed `.SRCINFO`, the package installs, `/usr/bin/tutabridge --help` runs, and the unit and license land where they should. `namcap` reports only its usual `$CARCH` style note.

`tutabridge-git` needs no change.